### PR TITLE
[Feat] Private RDS 로컬 EC2 인스턴스 터널링 작업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ bin/
 ### Application Properties ###
 src/main/resources/application.yml
 
+# SSH Tunneling
+*.pem

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+
+    // SSH Tunneling
+    implementation 'com.github.mwiede:jsch:0.2.17'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/evenly/blok/global/config/datasource/SshDataSourceConfig.java
+++ b/src/main/java/com/evenly/blok/global/config/datasource/SshDataSourceConfig.java
@@ -1,0 +1,41 @@
+package com.evenly.blok.global.config.datasource;
+
+import javax.sql.DataSource;
+
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+import com.evenly.blok.global.config.ssh.SshTunnelingInitializer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Profile("local")
+@Configuration
+@RequiredArgsConstructor
+public class SshDataSourceConfig {
+
+	private final SshTunnelingInitializer initializer;
+	private final DataSourceProperties properties;
+
+	@Bean
+	@Primary
+	public DataSource dataSource() {
+		Integer forwardedPort = initializer.buildSshConnection();
+		String url = properties.getUrl().replace("[forwardedPort]", forwardedPort.toString());
+
+		log.info("Configuring DataSource with URL: {}", url);
+
+		return DataSourceBuilder.create()
+			.url(url)
+			.username(properties.getUsername())
+			.password(properties.getPassword())
+			.driverClassName(properties.getDriverClassName())
+			.build();
+	}
+}

--- a/src/main/java/com/evenly/blok/global/config/datasource/SshDataSourceConfig.java
+++ b/src/main/java/com/evenly/blok/global/config/datasource/SshDataSourceConfig.java
@@ -6,7 +6,6 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
 import com.evenly.blok.global.config.ssh.SshTunnelingInitializer;
@@ -24,7 +23,6 @@ public class SshDataSourceConfig {
 	private final DataSourceProperties properties;
 
 	@Bean
-	@Primary
 	public DataSource dataSource() {
 		Integer forwardedPort = initializer.buildSshConnection();
 		String url = properties.getUrl().replace("[forwardedPort]", forwardedPort.toString());

--- a/src/main/java/com/evenly/blok/global/config/ssh/SshTunnelingInitializer.java
+++ b/src/main/java/com/evenly/blok/global/config/ssh/SshTunnelingInitializer.java
@@ -1,0 +1,91 @@
+package com.evenly.blok.global.config.ssh;
+
+import java.util.Properties;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+
+import jakarta.annotation.PreDestroy;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Profile("local")
+@Component
+@Validated
+@Setter
+public class SshTunnelingInitializer {
+
+	@Value("${ssh.host}")
+	private String remoteJumpHost;
+
+	@Value("${ssh.user}")
+	private String user;
+
+	@Value("${ssh.port}")
+	private int sshPort;
+
+	@Value("${ssh.private-key-path}")
+	private String privateKey;
+
+	@Value("${ssh.db-host}")
+	private String databaseHost;
+
+	@Value("${ssh.db-port}")
+	private int databasePort;
+
+	private Session session;
+
+	@PreDestroy
+	public void closeSSH() {
+		if (session.isConnected())
+			session.disconnect();
+	}
+
+	public Integer buildSshConnection() {
+
+		Integer forwardedPort = null;
+
+		try {
+			log.info("start ssh tunneling..");
+			JSch jSch = new JSch();
+
+			log.info("creating ssh session");
+			jSch.addIdentity(privateKey);  // 개인키 설정
+
+			session = jSch.getSession(user, remoteJumpHost, sshPort);  // 터널링 세션 설정
+
+			Properties config = new Properties();
+			config.put("StrictHostKeyChecking", "no");
+			session.setConfig(config);
+			// 터미널에서 SSH 명령어로 처음 서버 접속 시 보이는 "Are you sure you want to continue connecting (yes/no)?" 메시지를 자동으로 "yes"로 처리하는 것과 같은 세팅
+
+			log.info("complete creating ssh session");
+
+			log.info("start connecting ssh connection");
+			session.connect();  // ssh 연결 시도
+
+			log.info("success connecting ssh connection ");
+
+			// 로컬의 남는 포트 하나와 원격 접속한 인스턴스의 db포트 연결
+			log.info("start forwarding");
+			forwardedPort = session.setPortForwardingL(0, databaseHost, databasePort);
+
+			// 로컬에서 원격 인스턴스를 터널링 하여 Private RDS 접근 성공
+			log.info("successfully connected to database from local");
+
+		} catch (Exception e) {
+			log.error("SSH tunneling failed with exception", e);
+			this.closeSSH();
+			System.exit(1);
+		}
+
+		// 연결된 RDS 와 연결된 로컬 port 반환
+		return forwardedPort;
+	}
+}

--- a/src/main/java/com/evenly/blok/global/config/ssh/SshTunnelingInitializer.java
+++ b/src/main/java/com/evenly/blok/global/config/ssh/SshTunnelingInitializer.java
@@ -11,21 +11,19 @@ import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Session;
 
 import jakarta.annotation.PreDestroy;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Profile("local")
 @Component
 @Validated
-@Setter
 public class SshTunnelingInitializer {
 
 	@Value("${ssh.host}")
-	private String remoteJumpHost;
+	private String sshHost;
 
 	@Value("${ssh.user}")
-	private String user;
+	private String sshUser;
 
 	@Value("${ssh.port}")
 	private int sshPort;
@@ -42,7 +40,7 @@ public class SshTunnelingInitializer {
 	private Session session;
 
 	@PreDestroy
-	public void closeSSH() {
+	public void closeSsh() {
 		if (session.isConnected())
 			session.disconnect();
 	}
@@ -58,7 +56,7 @@ public class SshTunnelingInitializer {
 			log.info("creating ssh session");
 			jSch.addIdentity(privateKey);  // 개인키 설정
 
-			session = jSch.getSession(user, remoteJumpHost, sshPort);  // 터널링 세션 설정
+			session = jSch.getSession(sshUser, sshHost, sshPort);  // 터널링 세션 설정
 
 			Properties config = new Properties();
 			config.put("StrictHostKeyChecking", "no");
@@ -72,7 +70,7 @@ public class SshTunnelingInitializer {
 
 			log.info("success connecting ssh connection ");
 
-			// 로컬의 남는 포트 하나와 원격 접속한 인스턴스의 db포트 연결
+			// 로컬의 남는 포트 하나와 원격 접속한 인스턴스의 DB 포트 연결
 			log.info("start forwarding");
 			forwardedPort = session.setPortForwardingL(0, databaseHost, databasePort);
 
@@ -81,7 +79,7 @@ public class SshTunnelingInitializer {
 
 		} catch (Exception e) {
 			log.error("SSH tunneling failed with exception", e);
-			this.closeSSH();
+			this.closeSsh();
 			System.exit(1);
 		}
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,49 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:[forwardedPort]/${DB_DATABASE}?useUnicode=true&characterEncoding=UTF-8&serverTimezone=UTC&useSSL=true
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+        default_schema: development
+
+    open-in-view: false
+
+swagger:
+  version: 0.0.1
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /swagger-ui
+    disable-swagger-default-url: true
+    display-request-duration: true
+    tags-sorter: alpha
+    operations-sorter: alpha
+    syntax-highlight:
+      theme: none
+    urls-primary-name: 16th
+
+# SSH Tunnel Configuration
+ssh:
+  host: ${SSH_HOST}
+  user: ${SSH_USER}
+  private-key-path: ${SSH_PRIVATE_KEY_PATH}
+  port: ${SSH_PORT}
+  db-host: ${DB_HOST}
+  db-port: ${DB_PORT}


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
issue https://github.com/depromeet/16th-team2-BE/issues/2

## 📌 개발 이유
* AWS 정책변경으로 인해 2024년 부터 IPv4 주소를 활용하는 리소스에 비용을 부과하게 되어서 프리티어를 활용하더라도 비용이 부과되는 문제 발생
* RDS DB 또한 Public 으로 열게되면 IPv4 주소가 할당되어 비용을 부과
* Private 으로 설정하면 비용 문제가 해결되지만, 문제는 Private RDS 는 해당 RDS 와 동일한 VPC 내부 환경에서만 접근이 가능해짐
  * 로컬에서 빌드하는 서버, DB IDE(Datagrip) 등 에서 접근 불가능
* 따라서 로컬에서 Private RDS 에 접근하기 위해서는 
  * ```Local ⇒ 같은 VPC 내의 EC2 인스턴스 (SSH 접속) ⇒ RDS ```
  * 순으로 요청을 돌려서 접근해야 함

## 💻 수정 사항
* Local .env resource 파일 생성
  * 로컬에서 실행될 때에만 터널링을 실행하도록 분기 처리
  * RDS 의 로컬 포워딩 Port 를 DataSource url 에 설정하도록 세팅


* 실행순서
  * SshTunnelingInitializer
    1. local resource 파일에서 SSH 터널링에 필요한 환경변수 조회
    2. EC2 Public IP 와 pem key 를 활용해서 EC2 SSH 접속 시도
    3. 접속 성공 시, EC2 터널링 세션을 활용하여 로컬에서 남는 Port 에 RDS DB 포트포워딩
    4. 최종적으로 로컬 Port ⇒ (EC2 터널) ⇒ RDS 접근 성공
  * SshDataSourceConfig
    1. 로컬에서 프로젝트 빌드와 동시에 위 Initializer 의 SSH 터널링을 통한 RDS 포워딩 작업 실행
    2. datasource url 의 DB 포트 "[forwardedPort]" 를 포워딩된 로컬 포트로 대체
    3. 변경된 url 을 기반으로 새로운 datasource 설정
    4. 로컬에서 Private RDS 접근 성공

## 🧪 테스트 방법
노션에서 pem key 및 업데이트된 .env 확인

1. 프로젝트 폴더 root 에 EC2 pem key 를 위치
2. ```chmod 400 {키파일}.pem``` 명령어를 통해 접근키에 권한 부여
3. .env 에 SSH 관련 환경변수들 추가
4. 로컬 실행환경의 Spring Profile ⇒ local 변경

이후, 빌드 테스트 및 로그 확인

## 🎯 리뷰 포인트
* 최대한 상세하게 확인하실 수 있도록 주석과 Log 에 작업 내용 남겨두었습니다!
* 추가로 궁금하신 부분은 편하게 다 물어봐주세용

## 📁 레퍼런스
https://gamxong.tistory.com/148