### PR TITLE
[Feat] OAuth 및 JWT 인증 기능 구현 및 Composite 패턴 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,13 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
-
     // SSH Tunneling
     implementation 'com.github.mwiede:jsch:0.2.17'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 }
 

--- a/src/main/java/com/evenly/took/TookApplication.java
+++ b/src/main/java/com/evenly/took/TookApplication.java
@@ -2,12 +2,13 @@ package com.evenly.took;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class TookApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(TookApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/evenly/took/domain/auth/api/OAuthApi.java
+++ b/src/main/java/com/evenly/took/domain/auth/api/OAuthApi.java
@@ -1,0 +1,46 @@
+package com.evenly.took.domain.auth.api;
+
+import java.io.IOException;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.evenly.took.domain.auth.domain.OAuthType;
+import com.evenly.took.global.response.SuccessResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Tag(name = "[1. OAuth]")
+public interface OAuthApi {
+
+	@Operation(
+		summary = "소셜 로그인 인가 URL 리다이렉트",
+		description = "지정된 OAuthType에 따른 소셜 로그인 인가 코드 요청 URL로 클라이언트를 리다이렉트합니다."
+	)
+	@ApiResponse(responseCode = "302", description = "리다이렉트 성공")
+	@GetMapping("/{oauthType}")
+	void redirectAuthRequestUrl(
+		@Parameter(description = "소셜 공급자 타입 (예: GOOGLE, KAKAO, APPLE)", required = true, example = "GOOGLE")
+		@PathVariable OAuthType oauthType,
+		HttpServletResponse response) throws IOException;
+
+	@Operation(
+		summary = "소셜 로그인 및 JWT 토큰 발급",
+		description = "소셜 로그인 인가 코드를 통해 JWT 토큰(Access Token)을 발급받습니다."
+	)
+	@ApiResponse(responseCode = "200", description = "로그인 성공",
+		content = @Content(schema = @Schema(implementation = SuccessResponse.class)))
+	@GetMapping("/login/{oauthType}")
+	SuccessResponse login(
+		@Parameter(description = "소셜 공급자 타입 (예: GOOGLE, KAKAO, APPLE)", required = true, example = "GOOGLE")
+		@PathVariable OAuthType oauthType,
+		@Parameter(description = "소셜 서버로부터 전달받은 인가 코드", required = true)
+		@RequestParam String code);
+}

--- a/src/main/java/com/evenly/took/domain/auth/api/OAuthController.java
+++ b/src/main/java/com/evenly/took/domain/auth/api/OAuthController.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/oauth")
-public class OAuthController {
+public class OAuthController implements OAuthApi {
 
 	private final OAuthService oauthService;
 

--- a/src/main/java/com/evenly/took/domain/auth/api/OAuthController.java
+++ b/src/main/java/com/evenly/took/domain/auth/api/OAuthController.java
@@ -1,0 +1,38 @@
+package com.evenly.took.domain.auth.api;
+
+import java.io.IOException;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.evenly.took.domain.auth.application.OAuthService;
+import com.evenly.took.domain.auth.domain.OAuthType;
+import com.evenly.took.domain.auth.dto.response.JwtResponse;
+import com.evenly.took.global.response.SuccessResponse;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/oauth")
+public class OAuthController {
+
+	private final OAuthService oauthService;
+
+	@GetMapping("/{oauthType}")
+	public void redirectAuthRequestUrl(@PathVariable OAuthType oauthType, HttpServletResponse response) throws
+		IOException {
+		String url = oauthService.getAuthCodeRequestUrl(oauthType);
+		response.sendRedirect(url);
+	}
+
+	@GetMapping("/login/{oauthType}")
+	public SuccessResponse login(@PathVariable OAuthType oauthType, @RequestParam String code) {
+		JwtResponse jwtResponse = oauthService.loginAndGenerateToken(oauthType, code);
+		return SuccessResponse.of(jwtResponse.accessToken());
+	}
+}

--- a/src/main/java/com/evenly/took/domain/auth/application/OAuthService.java
+++ b/src/main/java/com/evenly/took/domain/auth/application/OAuthService.java
@@ -1,0 +1,37 @@
+package com.evenly.took.domain.auth.application;
+
+import org.springframework.stereotype.Service;
+
+import com.evenly.took.domain.auth.client.UserClientComposite;
+import com.evenly.took.domain.auth.client.authcode.AuthCodeRequestUrlProviderComposite;
+import com.evenly.took.domain.auth.domain.OAuthType;
+import com.evenly.took.domain.auth.dto.response.JwtResponse;
+import com.evenly.took.domain.auth.jwt.JwtTokenProvider;
+import com.evenly.took.domain.user.dao.UserRepository;
+import com.evenly.took.domain.user.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+
+	private final AuthCodeRequestUrlProviderComposite authCodeComposite;
+	private final UserClientComposite userClientComposite;
+	private final UserRepository userRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public String getAuthCodeRequestUrl(OAuthType oauthType) {
+		return authCodeComposite.provide(oauthType);
+	}
+
+	public JwtResponse loginAndGenerateToken(OAuthType oauthType, String authCode) {
+		User user = userClientComposite.fetch(oauthType, authCode);
+		User savedUser = userRepository.findByOauthId(user.getOauthId())
+			.orElseGet(() -> userRepository.save(user));
+
+		String accessToken = jwtTokenProvider.generateAccessToken(savedUser);
+
+		return new JwtResponse(accessToken);
+	}
+}

--- a/src/main/java/com/evenly/took/domain/auth/client/UserClient.java
+++ b/src/main/java/com/evenly/took/domain/auth/client/UserClient.java
@@ -1,0 +1,11 @@
+package com.evenly.took.domain.auth.client;
+
+import com.evenly.took.domain.auth.domain.OAuthType;
+import com.evenly.took.domain.user.domain.User;
+
+public interface UserClient {
+
+	OAuthType supportType();
+
+	User fetch(String authCode);
+}

--- a/src/main/java/com/evenly/took/domain/auth/client/UserClientComposite.java
+++ b/src/main/java/com/evenly/took/domain/auth/client/UserClientComposite.java
@@ -1,0 +1,32 @@
+package com.evenly.took.domain.auth.client;
+
+import static com.evenly.took.global.exception.auth.oauth.OAuthErrorCode.*;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.evenly.took.domain.auth.domain.OAuthType;
+import com.evenly.took.domain.user.domain.User;
+import com.evenly.took.global.exception.auth.oauth.OAuthTypeNotFoundException;
+
+@Component
+public class UserClientComposite {
+
+	private final Map<OAuthType, UserClient> mapping;
+
+	public UserClientComposite(Set<UserClient> clients) {
+		mapping = clients.stream()
+			.collect(Collectors.toMap(UserClient::supportType, Function.identity()));
+	}
+
+	public User fetch(OAuthType oauthType, String authCode) {
+		return Optional.ofNullable(mapping.get(oauthType))
+			.orElseThrow(() -> new OAuthTypeNotFoundException(OAUTH_TYPE_NOT_FOUND))
+			.fetch(authCode);
+	}
+}

--- a/src/main/java/com/evenly/took/domain/auth/client/authcode/AuthCodeRequestUrlProvider.java
+++ b/src/main/java/com/evenly/took/domain/auth/client/authcode/AuthCodeRequestUrlProvider.java
@@ -1,0 +1,10 @@
+package com.evenly.took.domain.auth.client.authcode;
+
+import com.evenly.took.domain.auth.domain.OAuthType;
+
+public interface AuthCodeRequestUrlProvider {
+
+	OAuthType supportType();
+
+	String provide();
+}

--- a/src/main/java/com/evenly/took/domain/auth/client/authcode/AuthCodeRequestUrlProviderComposite.java
+++ b/src/main/java/com/evenly/took/domain/auth/client/authcode/AuthCodeRequestUrlProviderComposite.java
@@ -1,0 +1,31 @@
+package com.evenly.took.domain.auth.client.authcode;
+
+import static com.evenly.took.global.exception.auth.oauth.OAuthErrorCode.*;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.evenly.took.domain.auth.domain.OAuthType;
+import com.evenly.took.global.exception.auth.oauth.OAuthTypeNotFoundException;
+
+@Component
+public class AuthCodeRequestUrlProviderComposite {
+
+	private final Map<OAuthType, AuthCodeRequestUrlProvider> mapping;
+
+	public AuthCodeRequestUrlProviderComposite(Set<AuthCodeRequestUrlProvider> providers) {
+		mapping = providers.stream()
+			.collect(Collectors.toMap(AuthCodeRequestUrlProvider::supportType, Function.identity()));
+	}
+
+	public String provide(OAuthType oauthType) {
+		return Optional.ofNullable(mapping.get(oauthType))
+			.orElseThrow(() -> new OAuthTypeNotFoundException(OAUTH_TYPE_NOT_FOUND))
+			.provide();
+	}
+}

--- a/src/main/java/com/evenly/took/domain/auth/domain/OAuthId.java
+++ b/src/main/java/com/evenly/took/domain/auth/domain/OAuthId.java
@@ -1,0 +1,29 @@
+package com.evenly.took.domain.auth.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OAuthId {
+
+	@Column(name = "oauth_id", nullable = false)
+	private String oauthId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "oauth_type", nullable = false)
+	private OAuthType oauthType;
+
+	@Builder
+	public OAuthId(String oauthId, OAuthType oauthType) {
+		this.oauthId = oauthId;
+		this.oauthType = oauthType;
+	}
+}

--- a/src/main/java/com/evenly/took/domain/auth/domain/OAuthType.java
+++ b/src/main/java/com/evenly/took/domain/auth/domain/OAuthType.java
@@ -1,0 +1,10 @@
+package com.evenly.took.domain.auth.domain;
+
+public enum OAuthType {
+
+	GOOGLE, KAKAO, APPLE;
+
+	public static OAuthType fromName(String name) {
+		return OAuthType.valueOf(name.toUpperCase());
+	}
+}

--- a/src/main/java/com/evenly/took/domain/auth/dto/response/JwtResponse.java
+++ b/src/main/java/com/evenly/took/domain/auth/dto/response/JwtResponse.java
@@ -1,0 +1,6 @@
+package com.evenly.took.domain.auth.dto.response;
+
+public record JwtResponse(
+	String accessToken
+) {
+}

--- a/src/main/java/com/evenly/took/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/evenly/took/domain/auth/jwt/JwtTokenProvider.java
@@ -9,7 +9,7 @@ import java.util.Date;
 import org.springframework.stereotype.Component;
 
 import com.evenly.took.domain.user.domain.User;
-import com.evenly.took.global.config.jwt.JwtProperties;
+import com.evenly.took.global.config.properties.jwt.JwtProperties;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;

--- a/src/main/java/com/evenly/took/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/evenly/took/domain/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,79 @@
+package com.evenly.took.domain.auth.jwt;
+
+import static com.evenly.took.global.exception.auth.jwt.JwtErrorCode.*;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+import org.springframework.stereotype.Component;
+
+import com.evenly.took.domain.user.domain.User;
+import com.evenly.took.global.config.jwt.JwtProperties;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+	private final JwtProperties jwtProperties;
+
+	public String generateAccessToken(User user) {
+		Claims claims = generateClaims(user);
+		Date now = new Date();
+		Date expiredAt = new Date(now.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+		return buildAccessToken(claims, now, expiredAt);
+	}
+
+	private Claims generateClaims(final User user) {
+		Claims claims = Jwts.claims().setSubject(user.getId().toString());
+		claims.put("name", user.getName());
+		return claims;
+	}
+
+	private String buildAccessToken(Claims claims, Date now, Date expiredAt) {
+		Key key = getSigningKey();
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(now)
+			.setExpiration(expiredAt)
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	public boolean validateToken(String token) {
+		Key key = getSigningKey();
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token);
+			return true;
+		} catch (JwtException | IllegalArgumentException e) {
+			log.error(JWT_UNAUTHORIZED.getMessage());
+			return false;
+		}
+	}
+
+	public String getUserId(String token) {
+		Key key = getSigningKey();
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody()
+			.getSubject();
+	}
+
+	private Key getSigningKey() {
+		return Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes(StandardCharsets.UTF_8));
+	}
+}

--- a/src/main/java/com/evenly/took/domain/common/model/BaseTimeEntity.java
+++ b/src/main/java/com/evenly/took/domain/common/model/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.evenly.took.domain.common.model;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/evenly/took/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/evenly/took/domain/user/dao/UserRepository.java
@@ -1,0 +1,13 @@
+package com.evenly.took.domain.user.dao;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.evenly.took.domain.auth.domain.OAuthId;
+import com.evenly.took.domain.user.domain.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findByOauthId(OAuthId oAuthId);
+}

--- a/src/main/java/com/evenly/took/domain/user/domain/User.java
+++ b/src/main/java/com/evenly/took/domain/user/domain/User.java
@@ -1,0 +1,49 @@
+package com.evenly.took.domain.user.domain;
+
+import com.evenly.took.domain.auth.domain.OAuthId;
+import com.evenly.took.domain.common.model.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users", uniqueConstraints = {
+	@UniqueConstraint(
+		name = "oauth_id_unique",
+		columnNames = {"oauth_id", "oauth_type"}
+	)
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Embedded
+	private OAuthId oauthId;
+
+	@Column(name = "user_name")
+	private String name;
+
+	@Column(name = "user_profile_image")
+	private String profileImage;
+
+	@Builder
+	public User(OAuthId oauthId, String name, String profileImage) {
+		this.oauthId = oauthId;
+		this.name = name;
+		this.profileImage = profileImage;
+	}
+}

--- a/src/main/java/com/evenly/took/global/config/client/ClientConfig.java
+++ b/src/main/java/com/evenly/took/global/config/client/ClientConfig.java
@@ -1,0 +1,29 @@
+package com.evenly.took.global.config.client;
+
+import java.time.Duration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class ClientConfig {
+
+	private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(60);
+	private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(30);
+
+	@Bean
+	public RestClient.Builder restClientBuilder() {
+		return RestClient.builder()
+			.requestFactory(requestFactory());
+	}
+
+	private ClientHttpRequestFactory requestFactory() {
+		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+		requestFactory.setConnectTimeout(DEFAULT_CONNECTION_TIMEOUT);
+		requestFactory.setReadTimeout(DEFAULT_READ_TIMEOUT);
+		return requestFactory;
+	}
+}

--- a/src/main/java/com/evenly/took/global/config/jpa/JpaAuditingConfig.java
+++ b/src/main/java/com/evenly/took/global/config/jpa/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.evenly.took.global.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/evenly/took/global/config/jwt/JwtProperties.java
+++ b/src/main/java/com/evenly/took/global/config/jwt/JwtProperties.java
@@ -1,0 +1,14 @@
+package com.evenly.took.global.config.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+	String accessTokenSecret,
+	Long accessTokenExpirationTime
+) {
+
+	public Long accessTokenExpirationMilliTime() {
+		return accessTokenExpirationTime * 1000;
+	}
+}

--- a/src/main/java/com/evenly/took/global/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/evenly/took/global/config/properties/PropertiesConfig.java
@@ -1,0 +1,13 @@
+package com.evenly.took.global.config.properties;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import com.evenly.took.global.config.properties.jwt.JwtProperties;
+
+@EnableConfigurationProperties({
+	JwtProperties.class,
+})
+@Configuration
+public class PropertiesConfig {
+}

--- a/src/main/java/com/evenly/took/global/config/properties/jwt/JwtProperties.java
+++ b/src/main/java/com/evenly/took/global/config/properties/jwt/JwtProperties.java
@@ -1,4 +1,4 @@
-package com.evenly.took.global.config.jwt;
+package com.evenly.took.global.config.properties.jwt;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/com/evenly/took/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/evenly/took/global/config/security/WebSecurityConfig.java
@@ -37,6 +37,7 @@ public class WebSecurityConfig {
 		http.authorizeHttpRequests(authorize -> authorize
 			.requestMatchers("/public/**").permitAll()
 			.requestMatchers("/api/health").permitAll()
+			.requestMatchers("/api/oauth").permitAll()
 			.anyRequest().authenticated());
 
 		return http.build();

--- a/src/main/java/com/evenly/took/global/exception/auth/jwt/JwtErrorCode.java
+++ b/src/main/java/com/evenly/took/global/exception/auth/jwt/JwtErrorCode.java
@@ -1,0 +1,19 @@
+package com.evenly.took.global.exception.auth.jwt;
+
+import org.springframework.http.HttpStatus;
+
+import com.evenly.took.global.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtErrorCode implements ErrorCode {
+
+	JWT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "JWT를 찾을 수 없습니다."),
+	;
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/evenly/took/global/exception/auth/oauth/OAuthErrorCode.java
+++ b/src/main/java/com/evenly/took/global/exception/auth/oauth/OAuthErrorCode.java
@@ -1,0 +1,19 @@
+package com.evenly.took.global.exception.auth.oauth;
+
+import org.springframework.http.HttpStatus;
+
+import com.evenly.took.global.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuthErrorCode implements ErrorCode {
+
+	OAUTH_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "OAuth 타입을 찾을 수 없습니다."),
+	;
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/evenly/took/global/exception/auth/oauth/OAuthTypeNotFoundException.java
+++ b/src/main/java/com/evenly/took/global/exception/auth/oauth/OAuthTypeNotFoundException.java
@@ -1,0 +1,13 @@
+package com.evenly.took.global.exception.auth.oauth;
+
+import com.evenly.took.global.exception.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OAuthTypeNotFoundException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+}

--- a/src/main/java/com/evenly/took/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/evenly/took/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.evenly.took.global.security;
+
+import static com.evenly.took.global.exception.auth.jwt.JwtErrorCode.*;
+
+import java.io.IOException;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.evenly.took.domain.auth.jwt.JwtTokenProvider;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	public static final String BEARER = "Bearer ";
+	public static final String AUTHORIZATION = "Authorization";
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		String token = resolveToken(request);
+		if (token != null && jwtTokenProvider.validateToken(token)) {
+			// TODO: JWT 검증 성공 시 후속 처리를 진행 (현재는 헤더에 AUTHORIZATION 으로 넣음)
+			response.setHeader(AUTHORIZATION, jwtTokenProvider.getUserId(token));
+		} else {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, JWT_UNAUTHORIZED.getMessage());
+			return;
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader(AUTHORIZATION);
+		if (bearerToken != null && bearerToken.startsWith(BEARER)) {
+			return bearerToken.substring(7);
+		}
+		return null;
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,3 +37,7 @@ springdoc:
     operations-sorter: alpha
     syntax-highlight:
       theme: none
+
+jwt:
+  access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -47,3 +47,7 @@ ssh:
   port: ${SSH_PORT}
   db-host: ${DB_HOST}
   db-port: ${DB_PORT}
+
+jwt:
+  access-token-secret: ${JWT_ACCESS_TOKEN_SECRET:secret}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:7200}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -37,3 +37,7 @@ springdoc:
     operations-sorter: alpha
     syntax-highlight:
       theme: none
+
+jwt:
+  access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME}

--- a/src/test/java/com/evenly/took/domain/auth/client/UserClientCompositeTest.java
+++ b/src/test/java/com/evenly/took/domain/auth/client/UserClientCompositeTest.java
@@ -1,0 +1,73 @@
+package com.evenly.took.domain.auth.client.user;
+
+import static com.evenly.took.global.domain.TestUserFactory.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.evenly.took.domain.auth.client.UserClient;
+import com.evenly.took.domain.auth.client.UserClientComposite;
+import com.evenly.took.domain.auth.domain.OAuthId;
+import com.evenly.took.domain.auth.domain.OAuthType;
+import com.evenly.took.domain.user.domain.User;
+import com.evenly.took.global.exception.auth.oauth.OAuthTypeNotFoundException;
+import com.evenly.took.global.service.MockTest;
+
+class UserClientCompositeTest extends MockTest {
+
+	private static User testUser;
+
+	private UserClientComposite composite;
+	private final UserClient mockGoogleUserClient = new MockGoogleUserClient();
+
+	@BeforeEach
+	void setUp() {
+		testUser = createMockGoogleUser();
+		composite = new UserClientComposite(Set.of(mockGoogleUserClient));
+	}
+
+	@Test
+	void 유효한OAuthType_User_정상_반환() {
+		// given, when
+		User user = composite.fetch(OAuthType.GOOGLE, "testAuthCode");
+
+		// then
+		assertThat(user).isNotNull();
+		assertThat(user.getName()).isEqualTo(testUser.getName());
+	}
+
+	@Test
+	void 유효하지않은OAuthType_예외() {
+		// given
+		OAuthType invalidOAuthType = OAuthType.KAKAO;
+
+		// when
+		OAuthTypeNotFoundException exception = assertThrows(OAuthTypeNotFoundException.class, () -> {
+			composite.fetch(invalidOAuthType, "testAuthCode");
+		});
+
+		// then
+		assertThat(exception.getErrorCode()).isNotNull();
+	}
+
+	static class MockGoogleUserClient implements UserClient {
+
+		@Override
+		public OAuthType supportType() {
+			return OAuthType.GOOGLE;
+		}
+
+		@Override
+		public User fetch(String authCode) {
+			return User.builder()
+				.oauthId(new OAuthId("test", OAuthType.GOOGLE))
+				.name(testUser.getName())
+				.profileImage("test.png")
+				.build();
+		}
+	}
+}

--- a/src/test/java/com/evenly/took/domain/auth/client/authcode/AuthCodeRequestUrlProviderCompositeTest.java
+++ b/src/test/java/com/evenly/took/domain/auth/client/authcode/AuthCodeRequestUrlProviderCompositeTest.java
@@ -1,0 +1,63 @@
+package com.evenly.took.domain.auth.client.authcode;
+
+import static com.evenly.took.domain.auth.client.authcode.AuthCodeRequestUrlProviderCompositeTest.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.evenly.took.domain.auth.domain.OAuthType;
+import com.evenly.took.global.exception.auth.oauth.OAuthErrorCode;
+import com.evenly.took.global.exception.auth.oauth.OAuthTypeNotFoundException;
+import com.evenly.took.global.service.MockTest;
+
+class AuthCodeRequestUrlProviderCompositeTest extends MockTest {
+
+	static final String TEST_URL = "https://oauth.test";
+
+	private AuthCodeRequestUrlProviderComposite composite;
+	private final AuthCodeRequestUrlProvider mockGoogleAuthRequestUrlProvider = new MockGoogleAuthCodeRequestUrlProvider();
+
+	@BeforeEach
+	void setUp() {
+		composite = new AuthCodeRequestUrlProviderComposite(Set.of(mockGoogleAuthRequestUrlProvider));
+	}
+
+	@Test
+	void 유효한OAuthType_URL_정상_반환() {
+		// given, when
+		String url = composite.provide(OAuthType.GOOGLE);
+
+		// then
+		assertThat(url).isEqualTo(TEST_URL);
+	}
+
+	@Test
+	void 유효하지않은OAuthType_예외() {
+		// given
+		OAuthType invalidOAuthType = OAuthType.KAKAO;
+
+		// when
+		OAuthTypeNotFoundException exception = assertThrows(OAuthTypeNotFoundException.class, () -> {
+			composite.provide(invalidOAuthType);
+		});
+
+		// then
+		assertThat(exception.getErrorCode()).isEqualTo(OAuthErrorCode.OAUTH_TYPE_NOT_FOUND);
+	}
+}
+
+class MockGoogleAuthCodeRequestUrlProvider implements AuthCodeRequestUrlProvider {
+	@Override
+	public OAuthType supportType() {
+		return OAuthType.GOOGLE;
+	}
+
+	@Override
+	public String provide() {
+		return TEST_URL;
+	}
+}

--- a/src/test/java/com/evenly/took/domain/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/evenly/took/domain/auth/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,51 @@
+package com.evenly.took.domain.auth.jwt;
+
+import static com.evenly.took.global.domain.TestUserFactory.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.evenly.took.domain.user.domain.User;
+import com.evenly.took.global.config.properties.jwt.JwtProperties;
+import com.evenly.took.global.service.MockTest;
+
+class JwtTokenProviderTest extends MockTest {
+
+	private User testUser;
+
+	private JwtTokenProvider jwtTokenProvider;
+
+	@BeforeEach
+	void setUp() {
+		testUser = createMockGoogleUser();
+
+		String accessTokenSecret = "secretKey123secretKey123secretKey123";
+
+		JwtProperties jwtProperties = new JwtProperties(accessTokenSecret, 3600L);
+		jwtTokenProvider = new JwtTokenProvider(jwtProperties);
+	}
+
+	@Test
+	void accessToken_생성_성공() {
+		// given, when
+		String token = jwtTokenProvider.generateAccessToken(testUser);
+
+		// then
+		assertThat(token).isNotNull();
+	}
+
+	@Test
+	void accessToken_validate_성공() {
+		// given
+		String token = jwtTokenProvider.generateAccessToken(testUser);
+
+		// when
+		String userId = jwtTokenProvider.getUserId(token);
+
+		// then
+		assertThat(token).isNotNull();
+		assertThat(jwtTokenProvider.validateToken(token)).isTrue();
+		assertThat(userId).isEqualTo("1");
+	}
+}

--- a/src/test/java/com/evenly/took/global/domain/TestUserFactory.java
+++ b/src/test/java/com/evenly/took/global/domain/TestUserFactory.java
@@ -1,0 +1,28 @@
+package com.evenly.took.global.domain;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.evenly.took.domain.auth.domain.OAuthId;
+import com.evenly.took.domain.auth.domain.OAuthType;
+import com.evenly.took.domain.user.domain.User;
+
+public class TestUserFactory {
+
+	public static User createMockGoogleUser() {
+		OAuthId oAuthId = OAuthId.builder()
+			.oauthId("google-oauth-id")
+			.oauthType(OAuthType.GOOGLE)
+			.build();
+		return createMockUser("testUser", oAuthId, "testProfile");
+	}
+
+	public static User createMockUser(String name, OAuthId oauthId, String profileImage) {
+		User mcokUser = User.builder()
+			.oauthId(oauthId)
+			.name(name)
+			.profileImage(profileImage)
+			.build();
+		ReflectionTestUtils.setField(mcokUser, "id", 1L);
+		return mcokUser;
+	}
+}


### PR DESCRIPTION
### 관련 이슈가 있다면 적어주세요.
#12 

## 📌 개발 이유
- 소셜 OAuth 로그인 기능 및 JWT 인증 기능의 공통 부분을 구축하여 추후 진행할 소셜 로그인 기능 개발을 위한 사전 작업을 수행했습니다.  
- Composite 패턴을 적용하여 OAuth 클라이언트 확장성을 높이고, 예외 처리 및 인증 필터를 강화했습니다.  

## 💻 수정 사항

### 🚀 **기능 구현**  

✅ **OAuth API, Service, Controller**  
- 소셜 로그인 인가 코드 요청 및 JWT 토큰 발급 로직 구현  
- `OAuthService`에서 `UserClientComposite`을 활용하여 OAuth 사용자 정보 조회  
- `JwtTokenProvider`에서 JWT 토큰 발급 및 검증 기능 추가  

✅ **JWT 인증 및 필터링**  
- `JwtTokenProvider`: JWT 생성 및 검증 로직 구현  
- `JwtAuthenticationFilter`: Spring Security의 `OncePerRequestFilter`를 상속받아 JWT 검증 및 필터링 처리  

✅ **Composite 패턴 적용**  
- `AuthCodeRequestUrlProviderComposite`: OAuthType에 따른 인가 코드 요청 URL 제공  
- `UserClientComposite`: OAuthType에 따른 사용자 정보를 가져오는 클라이언트 관리  

✅ **Swagger 문서화**  
- OAuth API 관련 Swagger 주석 추가 (`@Tag`, `@Operation` 사용)  

✅ **JWT 관련 설정**  
- `JwtProperties`를 `@ConfigurationProperties`로 관리하도록 설정  

✅ **JPA Auditing 추가**  
- `BaseTimeEntity`를 추가하여 생성/수정 시간 자동 관리  

✅ **공통 Mock User Factory 추가**  
- `TestUserFactory`를 만들어 테스트 코드에서 공통적으로 사용 가능하도록 수정  

✅ **테스트 유틸 추가**  
- `TestUserFactory`에서 `User` 객체를 생성하고, `ReflectionTestUtils`를 활용하여 ID 값을 설정할 수 있도록 변경  

### **🧪 테스트 코드 추가**  

✅ **`JwtTokenProviderTest`**  
- JWT 액세스 토큰 생성 및 유효성 검증 테스트 추가  

✅ **`JwtAuthenticationFilterTest`**  
- JWT 필터 동작 테스트 (Spring Security 환경에서 인증 검증)  

✅ **`AuthCodeRequestUrlProviderCompositeTest`**  
- OAuth 타입별 인가 코드 요청 URL 생성 검증  

✅ **`UserClientCompositeTest`**  
- OAuth 타입별 사용자 정보 조회 검증  

✅ **공통 테스트 유틸 추가**  
- `TestUserFactory`를 통해 Mock User 추가

## 🧪 테스트 방법
- test 코드 실행  
- 소셜 로그인 적용 후 확인

## 🎯 리뷰 포인트
- 패키지 구조가 적합한지 확인해주세요.
-  `JwtAuthenticationFilter`에서 JWT 검증 성공 시 헤더에 AUTHORIZATION 으로 넣고 있는데, Cookie로 할지 이대로 할지 확인해주세요!
- `OAuthController` 부분이 적합한지 조금 헷갈려서 이 부분도 확인 부탁드립니다.!

## 🙏 리뷰어에게 남기고 싶은 말

### refresh 토큰 작업 시에 확인 list
- [ ] `JwtTokenProvider` 적용 여부
- [ ] `JwtProperties` 변수 추가 여부
- [ ] 기타 access token 과 관련된 부분 잘 적용되었는지