### PR TITLE
[Fix] 클래스별 restClient 분리를 위해 restClientBuilder 빈 복사 후 빌드

### DIFF
--- a/src/main/java/com/evenly/took/feature/auth/client/apple/AppleTokenProvider.java
+++ b/src/main/java/com/evenly/took/feature/auth/client/apple/AppleTokenProvider.java
@@ -34,7 +34,7 @@ public class AppleTokenProvider {
 		AppleTokenProviderErrorHandler errorHandler,
 		AppleProperties appleProperties,
 		AppleUrlProperties appleUrlProperties) {
-		this.restClient = restClientBuilder
+		this.restClient = restClientBuilder.clone()
 			.defaultStatusHandler(errorHandler)
 			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE,
 				StandardCharsets.UTF_8.name())

--- a/src/main/java/com/evenly/took/feature/auth/client/google/GoogleTokenProvider.java
+++ b/src/main/java/com/evenly/took/feature/auth/client/google/GoogleTokenProvider.java
@@ -27,7 +27,7 @@ public class GoogleTokenProvider {
 
 		this.googleProperties = googleProperties;
 		this.googleUrlProperties = googleUrlProperties;
-		this.restClient = restClientBuilder
+		this.restClient = restClientBuilder.clone()
 			.defaultStatusHandler(errorHandler)
 			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE,
 				StandardCharsets.UTF_8.name())

--- a/src/main/java/com/evenly/took/feature/auth/client/google/GoogleUserInfoProvider.java
+++ b/src/main/java/com/evenly/took/feature/auth/client/google/GoogleUserInfoProvider.java
@@ -22,7 +22,7 @@ public class GoogleUserInfoProvider {
 		GoogleUserInfoProviderErrorHandler errorHandler) {
 
 		this.googleUrlProperties = googleUrlProperties;
-		this.restClient = restClientBuilder
+		this.restClient = restClientBuilder.clone()
 			.defaultStatusHandler(errorHandler)
 			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE,
 				StandardCharsets.UTF_8.name())

--- a/src/main/java/com/evenly/took/feature/auth/client/kakao/KakaoTokenProvider.java
+++ b/src/main/java/com/evenly/took/feature/auth/client/kakao/KakaoTokenProvider.java
@@ -22,7 +22,7 @@ public class KakaoTokenProvider {
 		KakaoTokenProviderErrorHandler errorHandler,
 		KakaoProperties kakaoProperties) {
 
-		this.restClient = restClientBuilder
+		this.restClient = restClientBuilder.clone()
 			.defaultStatusHandler(errorHandler)
 			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE,
 				StandardCharsets.UTF_8.name())

--- a/src/main/java/com/evenly/took/feature/auth/client/kakao/KakaoUserInfoProvider.java
+++ b/src/main/java/com/evenly/took/feature/auth/client/kakao/KakaoUserInfoProvider.java
@@ -21,7 +21,7 @@ public class KakaoUserInfoProvider {
 		KakaoUserInfoProviderErrorHandler errorHandler,
 		KakaoProperties kakaoProperties) {
 
-		this.restClient = restClientBuilder
+		this.restClient = restClientBuilder.clone()
 			.defaultStatusHandler(errorHandler)
 			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE,
 				StandardCharsets.UTF_8.name())

--- a/src/test/java/com/evenly/took/feature/auth/client/apple/AppleTokenProviderTest.java
+++ b/src/test/java/com/evenly/took/feature/auth/client/apple/AppleTokenProviderTest.java
@@ -42,6 +42,8 @@ class AppleTokenProviderTest extends MockTest {
 			RestClient.Builder mockBuilder = mock(RestClient.Builder.class);
 			RestClient mockClient = mock(RestClient.class);
 
+			when(mockBuilder.clone())
+				.thenReturn(mockBuilder);
 			when(mockBuilder.defaultStatusHandler(any(AppleTokenProviderErrorHandler.class)))
 				.thenReturn(mockBuilder);
 			when(mockBuilder.defaultHeader(
@@ -81,6 +83,8 @@ class AppleTokenProviderTest extends MockTest {
 			RestClient mockClient = mock(RestClient.class);
 
 			// 체이닝을 위한 모킹 설정
+			when(mockBuilder.clone())
+				.thenReturn(mockBuilder);
 			when(mockBuilder.defaultStatusHandler(any(AppleTokenProviderErrorHandler.class)))
 				.thenReturn(mockBuilder);
 			when(mockBuilder.defaultHeader(

--- a/src/test/java/com/evenly/took/feature/auth/client/google/MockGoogleProviderTest.java
+++ b/src/test/java/com/evenly/took/feature/auth/client/google/MockGoogleProviderTest.java
@@ -28,6 +28,7 @@ public abstract class MockGoogleProviderTest extends MockTest {
 
 	@BeforeEach
 	public void setUpCommon() {
+		when(restClientBuilder.clone()).thenReturn(restClientBuilder);
 		when(restClientBuilder.defaultStatusHandler(any())).thenReturn(restClientBuilder);
 		when(restClientBuilder.defaultHeader("Content-Type", "application/x-www-form-urlencoded", "UTF-8"))
 			.thenReturn(restClientBuilder);


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
- #36 

## 📌 개발 이유
#### 문제상황
카카오, 구글, 애플 소셜 로그인 로직을 합친 후 카카오와 구글 API 호출 시 애플 에러가 발생하였습니다.
#### 원인분석
싱글톤으로 선언된 `RestClient.Builder` 빈을 함께 사용
→ 카카오, 구글 `RestClient`에 애플 에러 핸들러가 `defaultStatusHandler`로 적용됨

## 💻 수정 사항
각 `RestClient` 선언 시 `RestClient.Builder`를 클론하도록 하였습니다.

## 🧪 테스트 방법
1. 포스트맨으로 각 API 테스트
2. 목 테스트 코드 수정 및 성공 결과 확인

## 📁 레퍼런스
- `RestClient.Builder` 클론 방법
https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/client/RestClient.Builder.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
  - 여러 외부 인증 서비스(Apple, Google, Kakao)의 내부 구성 방식을 개선하여, 로그인 과정 중 발생할 수 있는 예기치 않은 문제를 최소화하고 안정적인 인증 경험을 제공합니다.
- **테스트**
  - 인증 기능에 대한 테스트 케이스를 보완 및 업데이트하여, 일관되고 신뢰할 수 있는 동작이 유지되도록 개선하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->