### PR TITLE
[Feat] 명함에 필요한 Entity 추가

### DIFF
--- a/src/main/java/com/evenly/took/feature/card/domain/Card.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/Card.java
@@ -25,7 +25,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,7 +32,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "cards")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
 public class Card extends BaseTimeEntity {
 

--- a/src/main/java/com/evenly/took/feature/card/domain/Card.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/Card.java
@@ -1,0 +1,118 @@
+package com.evenly.took.feature.card.domain;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.evenly.took.feature.card.domain.vo.Content;
+import com.evenly.took.feature.card.domain.vo.Project;
+import com.evenly.took.feature.card.domain.vo.SNS;
+import com.evenly.took.feature.common.model.BaseTimeEntity;
+import com.evenly.took.feature.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cards")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Card extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "career_id")
+	private Career career;
+
+	@Column(name = "preview_info")
+	@Enumerated(EnumType.STRING)
+	@NotNull
+	private PreviewInfoType previewInfo;
+
+	@Column(name = "nickname")
+	@NotNull
+	private String nickname;
+
+	@Column(name = "image_path")
+	private String imagePath;
+
+	@Column(name = "interest_domain")
+	@JdbcTypeCode(SqlTypes.JSON)
+	private List<String> interestDomain;
+
+	@Column(name = "summary")
+	private String summary;
+
+	@Column(name = "organization")
+	private String organization;
+
+	@Column(name = "sns")
+	@JdbcTypeCode(SqlTypes.JSON)
+	private List<SNS> sns;
+
+	@Column(name = "region")
+	private String region;
+
+	@Column(name = "hobby")
+	private String hobby;
+
+	@Column(name = "news")
+	private String news;
+
+	@Column(name = "content")
+	@JdbcTypeCode(SqlTypes.JSON)
+	private List<Content> content;
+
+	@Column(name = "project")
+	@JdbcTypeCode(SqlTypes.JSON)
+	private List<Project> project;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Builder
+	public Card(Career career, List<Content> content, String hobby, Long id, String imagePath,
+		List<String> interestDomain, LocalDateTime deletedAt, String news, String nickname, String organization,
+		PreviewInfoType previewInfo, List<Project> project, String region, List<SNS> sns, String summary, User user) {
+		this.career = career;
+		this.content = content;
+		this.hobby = hobby;
+		this.id = id;
+		this.imagePath = imagePath;
+		this.interestDomain = interestDomain;
+		this.deletedAt = deletedAt;
+		this.news = news;
+		this.nickname = nickname;
+		this.organization = organization;
+		this.previewInfo = previewInfo;
+		this.project = project;
+		this.region = region;
+		this.sns = sns;
+		this.summary = summary;
+		this.user = user;
+	}
+}

--- a/src/main/java/com/evenly/took/feature/card/domain/Card.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/Card.java
@@ -24,8 +24,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,6 +33,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "cards")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 public class Card extends BaseTimeEntity {
 
@@ -48,23 +49,21 @@ public class Card extends BaseTimeEntity {
 	@JoinColumn(name = "career_id")
 	private Career career;
 
-	@Column(name = "preview_info")
+	@Column(name = "preview_info", nullable = false)
 	@Enumerated(EnumType.STRING)
-	@NotNull
 	private PreviewInfoType previewInfo;
 
-	@Column(name = "nickname")
-	@NotNull
+	@Column(name = "nickname", nullable = false)
 	private String nickname;
 
 	@Column(name = "image_path")
 	private String imagePath;
 
-	@Column(name = "interest_domain")
+	@Column(name = "interest_domain", nullable = false)
 	@JdbcTypeCode(SqlTypes.JSON)
 	private List<String> interestDomain;
 
-	@Column(name = "summary")
+	@Column(name = "summary", nullable = false)
 	private String summary;
 
 	@Column(name = "organization")

--- a/src/main/java/com/evenly/took/feature/card/domain/Career.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/Career.java
@@ -15,7 +15,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,18 +30,15 @@ public class Career extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "job")
+	@Column(name = "job", nullable = false)
 	@Enumerated(EnumType.STRING)
-	@NotNull
 	private Job job;
 
-	@Column(name = "detail_job_kr")
+	@Column(name = "detail_job_kr", nullable = false)
 	@JdbcTypeCode(SqlTypes.JSON)
-	@NotNull
 	private List<String> detailJobKr;
 
-	@Column(name = "detail_job_en")
-	@NotNull
+	@Column(name = "detail_job_en", nullable = false)
 	private String detailJobEn;
 
 	@Builder

--- a/src/main/java/com/evenly/took/feature/card/domain/Career.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/Career.java
@@ -1,0 +1,54 @@
+package com.evenly.took.feature.card.domain;
+
+import java.util.List;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.evenly.took.feature.common.model.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "careers")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Career extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "job")
+	@Enumerated(EnumType.STRING)
+	@NotNull
+	private Job job;
+
+	@Column(name = "detail_job_kr")
+	@JdbcTypeCode(SqlTypes.JSON)
+	@NotNull
+	private List<String> detailJobKr;
+
+	@Column(name = "detail_job_en")
+	@NotNull
+	private String detailJobEn;
+
+	@Builder
+	public Career(Job job, List<String> detailJobKr, String detailJobEn) {
+		this.job = job;
+		this.detailJobKr = detailJobKr;
+		this.detailJobEn = detailJobEn;
+	}
+}

--- a/src/main/java/com/evenly/took/feature/card/domain/vo/Content.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/vo/Content.java
@@ -1,14 +1,9 @@
 package com.evenly.took.feature.card.domain.vo;
 
-import com.evenly.took.feature.card.dto.response.ContentResponse;
-
 public record Content(
 	String title,
 	String link,
 	String imageUrl,
 	String description
 ) {
-	public ContentResponse toDto() {
-		return new ContentResponse(title, link, imageUrl, description);
-	}
 }

--- a/src/main/java/com/evenly/took/feature/card/domain/vo/Content.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/vo/Content.java
@@ -1,0 +1,14 @@
+package com.evenly.took.feature.card.domain.vo;
+
+import com.evenly.took.feature.card.dto.response.ContentResponse;
+
+public record Content(
+	String title,
+	String link,
+	String imageUrl,
+	String description
+) {
+	public ContentResponse toDto() {
+		return new ContentResponse(title, link, imageUrl, description);
+	}
+}

--- a/src/main/java/com/evenly/took/feature/card/domain/vo/Project.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/vo/Project.java
@@ -1,0 +1,14 @@
+package com.evenly.took.feature.card.domain.vo;
+
+import com.evenly.took.feature.card.dto.response.ProjectResponse;
+
+public record Project(
+	String title,
+	String link,
+	String imageUrl,
+	String description
+) {
+	public ProjectResponse toDto() {
+		return new ProjectResponse(title, link, imageUrl, description);
+	}
+}

--- a/src/main/java/com/evenly/took/feature/card/domain/vo/Project.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/vo/Project.java
@@ -1,14 +1,9 @@
 package com.evenly.took.feature.card.domain.vo;
 
-import com.evenly.took.feature.card.dto.response.ProjectResponse;
-
 public record Project(
 	String title,
 	String link,
 	String imageUrl,
 	String description
 ) {
-	public ProjectResponse toDto() {
-		return new ProjectResponse(title, link, imageUrl, description);
-	}
 }

--- a/src/main/java/com/evenly/took/feature/card/domain/vo/SNS.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/vo/SNS.java
@@ -1,13 +1,9 @@
 package com.evenly.took.feature.card.domain.vo;
 
 import com.evenly.took.feature.card.domain.SNSType;
-import com.evenly.took.feature.card.dto.response.SNSResponse;
 
 public record SNS(
 	SNSType type,
 	String link
 ) {
-	public SNSResponse toDto() {
-		return new SNSResponse(type, link);
-	}
 }

--- a/src/main/java/com/evenly/took/feature/card/domain/vo/SNS.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/vo/SNS.java
@@ -1,0 +1,13 @@
+package com.evenly.took.feature.card.domain.vo;
+
+import com.evenly.took.feature.card.domain.SNSType;
+import com.evenly.took.feature.card.dto.response.SNSResponse;
+
+public record SNS(
+	SNSType type,
+	String link
+) {
+	public SNSResponse toDto() {
+		return new SNSResponse(type, link);
+	}
+}

--- a/src/main/java/com/evenly/took/feature/card/dto/response/ContentResponse.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/response/ContentResponse.java
@@ -1,5 +1,7 @@
 package com.evenly.took.feature.card.dto.response;
 
+import com.evenly.took.feature.card.domain.vo.Content;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "작성한 글 정보")
@@ -16,4 +18,8 @@ public record ContentResponse(
 	@Schema(description = "글 설명", example = "Spring Boot를 이용한 RESTful API 개발 방법을 소개합니다.")
 	String description
 ) {
+
+	public ContentResponse from(Content content) {
+		return new ContentResponse(content.title(), content.link(), content.imageUrl(), content.description());
+	}
 }

--- a/src/main/java/com/evenly/took/feature/card/dto/response/ProjectResponse.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/response/ProjectResponse.java
@@ -1,5 +1,7 @@
 package com.evenly.took.feature.card.dto.response;
 
+import com.evenly.took.feature.card.domain.vo.Project;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "프로젝트 정보")
@@ -16,4 +18,7 @@ public record ProjectResponse(
 	@Schema(description = "프로젝트 설명", example = "Spring Boot 기반 명함 관리 서비스")
 	String description
 ) {
+	public ProjectResponse from(Project project) {
+		return new ProjectResponse(project.title(), project.link(), project.imageUrl(), project.description());
+	}
 }

--- a/src/main/java/com/evenly/took/feature/card/dto/response/SNSResponse.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/response/SNSResponse.java
@@ -1,6 +1,7 @@
 package com.evenly.took.feature.card.dto.response;
 
 import com.evenly.took.feature.card.domain.SNSType;
+import com.evenly.took.feature.card.domain.vo.SNS;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -12,4 +13,7 @@ public record SNSResponse(
 	@Schema(description = "SNS 링크", example = "https://linkedin.com/in/username")
 	String link
 ) {
+	public SNSResponse form(SNS sns) {
+		return new SNSResponse(sns.type(), sns.link());
+	}
 }

--- a/src/main/java/com/evenly/took/feature/user/domain/User.java
+++ b/src/main/java/com/evenly/took/feature/user/domain/User.java
@@ -13,7 +13,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,12 +36,10 @@ public class User extends BaseTimeEntity {
 	@Embedded
 	private OAuthIdentifier oauthIdentifier;
 
-	@Column(name = "name")
-	@NotNull
+	@Column(name = "name", nullable = false)
 	private String name;
 
 	@Column(name = "email", nullable = false)
-	@NotNull
 	private String email;
 
 	@Column(name = "allow_push_notification")

--- a/src/main/java/com/evenly/took/feature/user/domain/User.java
+++ b/src/main/java/com/evenly/took/feature/user/domain/User.java
@@ -1,5 +1,7 @@
 package com.evenly.took.feature.user.domain;
 
+import java.time.LocalDateTime;
+
 import com.evenly.took.feature.auth.domain.OAuthIdentifier;
 import com.evenly.took.feature.common.model.BaseTimeEntity;
 
@@ -39,9 +41,15 @@ public class User extends BaseTimeEntity {
 	@NotNull
 	private String name;
 
-	@Column(name = "email")
+	@Column(name = "email", nullable = false)
 	@NotNull
 	private String email;
+
+	@Column(name = "allow_push_notification")
+	private Boolean allowPushNotification;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
 	@Builder
 	public User(OAuthIdentifier oauthIdentifier, String name, String email) {

--- a/src/main/java/com/evenly/took/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/evenly/took/global/config/swagger/SwaggerConfig.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +38,8 @@ public class SwaggerConfig {
 		return new OpenAPI()
 			.servers(swaggerServers())
 			.components(swaggerComponents())
-			.info(swaggerInfo());
+			.info(swaggerInfo())
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
 	}
 
 	private List<Server> swaggerServers() {


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
* #44 

## 📌 개발 이유
- 공통으로 사용해야할 JPA Entity 생성

## 💻 수정 사항
- `Card` Entity 추가
- `Career` Entity 추가
- `User` 컬럼 추가

자세한 스키마는 [노션 링크](https://www.notion.so/depromeet/6-1ae45b4338b3800b81f0dbb1fea0404f?pvs=4) 확인

## 🧪 테스트 방법
- DDL 스키마 확인



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 카드 관련 상세 정보 관리를 위한 기능이 추가되어, 경력, 콘텐츠, 프로젝트, SNS 정보 등을 보다 효과적으로 등록하고 활용할 수 있습니다.
  - 사용자 프로필에 푸시 알림 옵션과 탈퇴 시각 기록 기능이 도입되어, 보다 유연한 사용자 관리가 가능합니다.
    
- **문서**
  - API 문서 보안이 강화되어, Bearer 인증을 통한 보다 안전한 접근이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->