### PR TITLE
[Feat] Docker 배포 환경 KST 적용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ RUN ./gradlew build -x test
 
 # Multi Stage Build
 FROM openjdk:17-jdk-slim AS deployment
+
+# KST Timezone Setup
+RUN apt-get update && apt-get install -y tzdata
+ENV TZ=Asia/Seoul
+
 WORKDIR /app
 
 COPY --from=build /app/build/libs/*.jar app.jar


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
- #59 

## 📌 개발 이유
배포환경에서 Local Timestamp (createdAt, updatedAt, deletedAt 등) 를 불러오거나 저장할 때 한국시간으로 적용하기 위한 작업입니다.

## 💻 수정 사항
DockerFile 배포 환경에 시간 관련 패키지 install & TimeZone Asia/Seoul 적용

## 🧪 테스트 방법
Dev 서버 API 로 저장될 때, DB 테이블에 저장되는 시간 KST 로 적용되는지 확인



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 애플리케이션 컨테이너의 기본 시간대를 한국 표준시(KST)로 설정하여, 사용자에게 정확한 현지 시간 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->