### PR TITLE
[Feat] FCM 푸시알림 초기 설계

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.jsoup:jsoup:1.18.1'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
@@ -65,7 +64,11 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
     // crawling
+    implementation 'org.jsoup:jsoup:1.18.1'
     implementation 'org.seleniumhq.selenium:selenium-java:4.29.0'
+
+    // firebase
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/evenly/took/feature/auth/application/AuthService.java
+++ b/src/main/java/com/evenly/took/feature/auth/application/AuthService.java
@@ -42,6 +42,7 @@ public class AuthService {
 		User user = userClientComposite.fetch(oauthType, context);
 		User savedUser = userRepository.findByOauthIdentifier(user.getOauthIdentifier())
 			.orElseGet(() -> userRepository.save(user));
+		// TODO UserDevice (token, user) 필드로 조회한 게 없으면 추가하거나 주인 변경 (멀티디바이스 & 한 기기 당 여러 사용자 상황 고려)
 		TokenDto tokens = tokenProvider.provideTokens(savedUser);
 		return new AuthResponse(tokens, savedUser);
 	}

--- a/src/main/java/com/evenly/took/feature/notification/config/FcmConfig.java
+++ b/src/main/java/com/evenly/took/feature/notification/config/FcmConfig.java
@@ -1,0 +1,47 @@
+package com.evenly.took.feature.notification.config;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import com.evenly.took.feature.notification.exception.NotificationErrorCode;
+import com.evenly.took.global.exception.TookException;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+public class FcmConfig {
+
+	@Value("${fcm.secret-key}")
+	private String secretKey;
+
+	@PostConstruct
+	public void initialize() {
+		if (!FirebaseApp.getApps().isEmpty()) {
+			log.info("FCM 앱 실행 성공");
+			return;
+		}
+		try {
+			FirebaseApp.initializeApp(options());
+			log.info("FCM 앱 초기화 성공");
+		} catch (IOException ex) {
+			log.error("FCM 앱 초기화 실패", ex);
+			throw new TookException(NotificationErrorCode.FCM_SERVER_ERROR);
+		}
+	}
+
+	private FirebaseOptions options() throws IOException {
+		try (ByteArrayInputStream credentials = new ByteArrayInputStream(secretKey.getBytes())) {
+			return FirebaseOptions.builder()
+				.setCredentials(GoogleCredentials.fromStream(credentials))
+				.build();
+		}
+	}
+}

--- a/src/main/java/com/evenly/took/feature/notification/domain/DevicePlatform.java
+++ b/src/main/java/com/evenly/took/feature/notification/domain/DevicePlatform.java
@@ -1,0 +1,9 @@
+package com.evenly.took.feature.notification.domain;
+
+public enum DevicePlatform {
+
+	ANDROID,
+	IOS,
+	WEB,
+	;
+}

--- a/src/main/java/com/evenly/took/feature/notification/domain/Notification.java
+++ b/src/main/java/com/evenly/took/feature/notification/domain/Notification.java
@@ -1,0 +1,36 @@
+package com.evenly.took.feature.notification.domain;
+
+import com.evenly.took.feature.common.model.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "notifications")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Notification extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_device")
+	private UserDevice userDevice;
+
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	// TODO 기획 확정 후 필드 추가 예정
+}

--- a/src/main/java/com/evenly/took/feature/notification/domain/UserDevice.java
+++ b/src/main/java/com/evenly/took/feature/notification/domain/UserDevice.java
@@ -1,0 +1,57 @@
+package com.evenly.took.feature.notification.domain;
+
+import java.time.LocalDateTime;
+
+import com.evenly.took.feature.common.model.BaseTimeEntity;
+import com.evenly.took.feature.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_devices")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class UserDevice extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@Column(name = "fcm_token", unique = true, nullable = false)
+	private String fcmToken;
+
+	@Column(name = "platform", nullable = false)
+	private DevicePlatform platform;
+
+	@Column(name = "allow_push_notification", nullable = false)
+	private boolean allowPushNotification;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Builder
+	public UserDevice(Long id, User user, String fcmToken, DevicePlatform platform) {
+		this.id = id;
+		this.user = user;
+		this.fcmToken = fcmToken;
+		this.platform = platform;
+		this.allowPushNotification = false;
+		this.deletedAt = null;
+	}
+}

--- a/src/main/java/com/evenly/took/feature/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/evenly/took/feature/notification/exception/NotificationErrorCode.java
@@ -1,0 +1,19 @@
+package com.evenly.took.feature.notification.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.evenly.took.global.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+
+	FCM_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 서버 연결 과정에서 에러가 발생하였습니다."),
+	;
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/evenly/took/feature/user/domain/User.java
+++ b/src/main/java/com/evenly/took/feature/user/domain/User.java
@@ -42,9 +42,6 @@ public class User extends BaseTimeEntity {
 	@Column(name = "email", nullable = false)
 	private String email;
 
-	@Column(name = "allow_push_notification")
-	private Boolean allowPushNotification;
-
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,3 +82,6 @@ aws:
   s3:
     bucket: ${BUCKET_NAME}
     env: ${BUCKET_ENV}
+
+fcm:
+  secret-key: ${FCM_SECRET_KEY_DEV} # TODO prod 환경 분리

--- a/src/test/java/com/evenly/took/TookApplicationTests.java
+++ b/src/test/java/com/evenly/took/TookApplicationTests.java
@@ -4,8 +4,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+import com.evenly.took.global.config.TestConfig;
+
 @ActiveProfiles("test")
+@SpringBootTest(classes = TestConfig.class)
 class TookApplicationTests {
 
 	@Test

--- a/src/test/java/com/evenly/took/feature/card/api/CardIntegrationTest.java
+++ b/src/test/java/com/evenly/took/feature/card/api/CardIntegrationTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -29,7 +28,6 @@ import com.evenly.took.feature.card.dto.request.LinkRequest;
 import com.evenly.took.feature.card.dto.response.ScrapResponse;
 import com.evenly.took.feature.card.exception.CardErrorCode;
 import com.evenly.took.global.aws.s3.S3Service;
-import com.evenly.took.global.config.testcontainers.S3TestConfig;
 import com.evenly.took.global.exception.TookException;
 import com.evenly.took.global.integration.JwtMockIntegrationTest;
 
@@ -37,7 +35,6 @@ import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
-@Import(S3TestConfig.class)
 public class CardIntegrationTest extends JwtMockIntegrationTest {
 
 	@MockitoBean

--- a/src/test/java/com/evenly/took/global/aws/s3/S3ServiceTest.java
+++ b/src/test/java/com/evenly/took/global/aws/s3/S3ServiceTest.java
@@ -4,17 +4,11 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ActiveProfiles;
 
-import com.evenly.took.global.config.testcontainers.S3TestConfig;
+import com.evenly.took.global.service.ServiceTest;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@Import(S3TestConfig.class)
-class S3ServiceTest {
+class S3ServiceTest extends ServiceTest {
 
 	@Autowired
 	private S3Service s3Service;

--- a/src/test/java/com/evenly/took/global/config/FcmTestConfig.java
+++ b/src/test/java/com/evenly/took/global/config/FcmTestConfig.java
@@ -1,0 +1,18 @@
+package com.evenly.took.global.config;
+
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import com.evenly.took.feature.notification.config.FcmConfig;
+
+@TestConfiguration
+public class FcmTestConfig {
+
+	@Bean
+	@Primary
+	public FcmConfig fcmConfig() {
+		return Mockito.mock(FcmConfig.class);
+	}
+}

--- a/src/test/java/com/evenly/took/global/config/TestConfig.java
+++ b/src/test/java/com/evenly/took/global/config/TestConfig.java
@@ -1,0 +1,18 @@
+package com.evenly.took.global.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+import com.evenly.took.global.config.testcontainers.MySQLTestConfig;
+import com.evenly.took.global.config.testcontainers.RedisTestConfig;
+import com.evenly.took.global.config.testcontainers.S3TestConfig;
+
+@Import({
+	FcmTestConfig.class,
+	MySQLTestConfig.class,
+	S3TestConfig.class,
+	RedisTestConfig.class
+})
+@TestConfiguration
+public class TestConfig {
+}

--- a/src/test/java/com/evenly/took/global/controller/ControllerTest.java
+++ b/src/test/java/com/evenly/took/global/controller/ControllerTest.java
@@ -10,9 +10,10 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.evenly.took.global.config.TestConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@SpringBootTest
+@SpringBootTest(classes = TestConfig.class)
 @AutoConfigureMockMvc
 @ExtendWith(SpringExtension.class)
 @Transactional

--- a/src/test/java/com/evenly/took/global/helper/DatabaseCleaner.java
+++ b/src/test/java/com/evenly/took/global/helper/DatabaseCleaner.java
@@ -1,14 +1,9 @@
 package com.evenly.took.global.helper;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 
-import com.evenly.took.global.config.testcontainers.MySQLTestConfig;
-import com.evenly.took.global.config.testcontainers.RedisTestConfig;
-
 @Component
-@Import({RedisTestConfig.class, MySQLTestConfig.class, MysqlCleaner.class, RedisCleaner.class})
 public class DatabaseCleaner {
 
 	@Autowired

--- a/src/test/java/com/evenly/took/global/integration/IntegrationTest.java
+++ b/src/test/java/com/evenly/took/global/integration/IntegrationTest.java
@@ -6,13 +6,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.evenly.took.global.config.TestConfig;
 import com.evenly.took.global.helper.DatabaseManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.restassured.RestAssured;
 
 @ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
 public abstract class IntegrationTest extends DatabaseManager {
 
 	@LocalServerPort

--- a/src/test/java/com/evenly/took/global/redis/RedisServiceTest.java
+++ b/src/test/java/com/evenly/took/global/redis/RedisServiceTest.java
@@ -6,16 +6,10 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 
-import com.evenly.took.global.config.testcontainers.RedisTestConfig;
+import com.evenly.took.global.service.ServiceTest;
 
-@SpringBootTest
-@ActiveProfiles("test")
-@Import(RedisTestConfig.class)
-class RedisTest {
+class RedisServiceTest extends ServiceTest {
 
 	@Autowired
 	private RedisService redisService;

--- a/src/test/java/com/evenly/took/global/service/ServiceTest.java
+++ b/src/test/java/com/evenly/took/global/service/ServiceTest.java
@@ -3,10 +3,11 @@ package com.evenly.took.global.service;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.evenly.took.global.config.TestConfig;
 import com.evenly.took.global.helper.DatabaseManager;
 
 @ActiveProfiles("test")
-@SpringBootTest
+@SpringBootTest(classes = TestConfig.class)
 public abstract class ServiceTest extends DatabaseManager {
 
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -39,3 +39,6 @@ oauth:
   kakao:
     client-id: clientId
     redirect-uri: redirectUri
+
+fcm:
+  secret-key: test


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.

## 📌 개발 이유
푸시알림 기능 도입으로 인해 필요해진 FCM 초기 세팅 작업을 진행하였습니다.

## 💻 수정 사항
- 멀티디바이스 환경 구축을 위해 UserDevice 테이블을 추가하였습니다.
- 알림 내역이 관리되도록 Notification 테이블을 추가하였습니다.
- 푸시알림 권한의 대상을 사용자가 아닌 디바이스로 변경하였습니다. (여러 디바이스 당 다른 권한 부여 가능하도록)
- FCM 서버를 연결하였습니다.
    - 시크릿키를 환경변수에 추가해두었습니다.
    - 테스트 환경(IntegrationTest, ServiceTest 기준)에서는 FCM 서버에 의존하지 않도록 모킹해두었습니다. 해당 과정에서 각 클래스에 흩어져있던 import문을 정리하였습니다. 모든 import문은 TestConfig에서 관리되도록 하였습니다!

## 🎯 리뷰 포인트
푸시알림 권한을 받는 시점 관련해서 [노션 글](https://www.notion.so/depromeet/1bb45b4338b380c5a382de4e4f0cda09?pvs=4) 작성해두었습니다.

## 📁 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 알림 시스템과 사용자 기기 등록 기능이 추가되어 다양한 플랫폼(안드로이드, iOS, 웹)에서 보다 효과적으로 알림을 전달합니다.
	- Firebase Cloud Messaging(Firebase 클라우드 메시징) 설정을 위한 새로운 구성 항목이 추가되었습니다.
- **리팩토링**
	- 인증 과정에서 향후 사용자 기기 소유권 처리를 고려한 개선 사항이 반영되었습니다.
	- 기존 사용자 프로필의 푸시 알림 설정 항목이 제거되어, 알림 관리 체계가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->