### PR TITLE
[Feat] 폴더 기본 CRUD API 추가

### DIFF
--- a/src/main/java/com/evenly/took/feature/card/api/CardApi.java
+++ b/src/main/java/com/evenly/took/feature/card/api/CardApi.java
@@ -4,18 +4,25 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.evenly.took.feature.card.domain.Job;
+import com.evenly.took.feature.card.dto.request.AddCardRequest;
+import com.evenly.took.feature.card.dto.request.AddFolderRequest;
 import com.evenly.took.feature.card.dto.request.CardDetailRequest;
-import com.evenly.took.feature.card.dto.request.CreateCardRequest;
+import com.evenly.took.feature.card.dto.request.FixFolderRequest;
 import com.evenly.took.feature.card.dto.request.LinkRequest;
+import com.evenly.took.feature.card.dto.request.RemoveFolderRequest;
 import com.evenly.took.feature.card.dto.response.CardDetailResponse;
 import com.evenly.took.feature.card.dto.response.CareersResponse;
+import com.evenly.took.feature.card.dto.response.FoldersResponse;
 import com.evenly.took.feature.card.dto.response.MyCardListResponse;
 import com.evenly.took.feature.card.dto.response.ScrapResponse;
 import com.evenly.took.feature.user.domain.User;
+import com.evenly.took.global.exception.dto.ErrorResponse;
 import com.evenly.took.global.response.SuccessResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -63,8 +70,63 @@ public interface CardApi {
 	})
 	SuccessResponse<Void> addCard(
 		User user,
-		CreateCardRequest request,
+		AddCardRequest request,
 		@Parameter(hidden = true)
 		MultipartFile profileImage
+	);
+
+	@Operation(
+		summary = "폴더 생성",
+		description = "새로운 폴더를 생성합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "201", description = "폴더 생성 성공")
+	})
+	SuccessResponse<Void> addFolder(
+		User user,
+		AddFolderRequest request
+	);
+
+	@Operation(
+		summary = "폴더 목록 조회",
+		description = "모든 폴더 목록을 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "폴더 목록 조회")
+	})
+	SuccessResponse<FoldersResponse> getFolders(
+		User user
+	);
+
+	@Operation(
+		summary = "폴더 이름 변경",
+		description = "폴더 이름을 변경합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "폴더 이름 변경 성공"),
+		@ApiResponse(responseCode = "404", description = "폴더를 찾을 수 없음",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "403", description = "폴더에 대한 권한 없음",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "400", description = "이미 삭제된 폴더",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	SuccessResponse<Void> fixFolder(
+		User user,
+		FixFolderRequest request
+	);
+
+	@Operation(
+		summary = "폴더 제거",
+		description = "명함 폴더를 제거합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "폴더 제거 성공"),
+		@ApiResponse(responseCode = "404", description = "폴더를 찾을 수 없음",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "403", description = "폴더에 대한 권한 없음",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "400", description = "이미 삭제된 폴더",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	SuccessResponse<Void> removeFolder(
+		User user,
+		RemoveFolderRequest request
 	);
 }

--- a/src/main/java/com/evenly/took/feature/card/api/CardController.java
+++ b/src/main/java/com/evenly/took/feature/card/api/CardController.java
@@ -3,9 +3,11 @@ package com.evenly.took.feature.card.api;
 import java.util.Set;
 
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -14,11 +16,15 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.evenly.took.feature.card.application.CardService;
 import com.evenly.took.feature.card.domain.Job;
+import com.evenly.took.feature.card.dto.request.AddCardRequest;
+import com.evenly.took.feature.card.dto.request.AddFolderRequest;
 import com.evenly.took.feature.card.dto.request.CardDetailRequest;
-import com.evenly.took.feature.card.dto.request.CreateCardRequest;
+import com.evenly.took.feature.card.dto.request.FixFolderRequest;
 import com.evenly.took.feature.card.dto.request.LinkRequest;
+import com.evenly.took.feature.card.dto.request.RemoveFolderRequest;
 import com.evenly.took.feature.card.dto.response.CardDetailResponse;
 import com.evenly.took.feature.card.dto.response.CareersResponse;
+import com.evenly.took.feature.card.dto.response.FoldersResponse;
 import com.evenly.took.feature.card.dto.response.MyCardListResponse;
 import com.evenly.took.feature.card.dto.response.ScrapResponse;
 import com.evenly.took.feature.user.domain.User;
@@ -68,12 +74,12 @@ public class CardController implements CardApi {
 	@PostMapping(value = "/api/card", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public SuccessResponse<Void> addCard(
 		@LoginUser User user,
-		@ModelAttribute CreateCardRequest request,
+		@ModelAttribute AddCardRequest request,
 		@RequestPart("profileImage") MultipartFile profileImage) {
 
 		// MultiPart 형식의 데이터의 경우, 유효성 검증이 RequestDTO 역직렬화 시, 체크가 안되는 문제가 있어 이후 개별적으로 진행
 		Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-		Set<ConstraintViolation<CreateCardRequest>> violations = validator.validate(request);
+		Set<ConstraintViolation<AddCardRequest>> violations = validator.validate(request);
 
 		if (!violations.isEmpty()) {
 			throw new ConstraintViolationException("요청 필드 유효성 검사 실패", violations);
@@ -83,4 +89,29 @@ public class CardController implements CardApi {
 		cardService.createCard(user, request, profileImageKey);
 		return SuccessResponse.created("명함 생성 성공");
 	}
+
+	@PostMapping("/api/card/folder")
+	public SuccessResponse<Void> addFolder(@LoginUser User user, @RequestBody @Valid AddFolderRequest request) {
+		cardService.createFolder(user, request);
+		return SuccessResponse.created("폴더 생성 성공");
+	}
+
+	@GetMapping("/api/card/folders")
+	public SuccessResponse<FoldersResponse> getFolders(@LoginUser User user) {
+		FoldersResponse response = cardService.findFolders(user);
+		return SuccessResponse.of(response);
+	}
+
+	@PutMapping("/api/card/folder")
+	public SuccessResponse<Void> fixFolder(@LoginUser User user, @RequestBody @Valid FixFolderRequest request) {
+		cardService.updateFolder(user, request);
+		return SuccessResponse.ok("폴더 이름 변경 성공");
+	}
+
+	@DeleteMapping("/api/card/folder")
+	public SuccessResponse<Void> removeFolder(@LoginUser User user, @RequestBody @Valid RemoveFolderRequest request) {
+		cardService.deleteFolder(user, request);
+		return SuccessResponse.ok("폴더 제거 성공");
+	}
+
 }

--- a/src/main/java/com/evenly/took/feature/card/dao/FolderRepository.java
+++ b/src/main/java/com/evenly/took/feature/card/dao/FolderRepository.java
@@ -1,0 +1,11 @@
+package com.evenly.took.feature.card.dao;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.evenly.took.feature.card.domain.Folder;
+
+public interface FolderRepository extends JpaRepository<Folder, Long> {
+	List<Folder> findAllByUserIdAndDeletedAtIsNull(Long userId);
+}

--- a/src/main/java/com/evenly/took/feature/card/domain/Folder.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/Folder.java
@@ -1,0 +1,56 @@
+package com.evenly.took.feature.card.domain;
+
+import java.time.LocalDateTime;
+
+import com.evenly.took.feature.common.model.BaseTimeEntity;
+import com.evenly.took.feature.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "folders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Folder extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Builder
+	public Folder(LocalDateTime deletedAt, String name, User user) {
+		this.deletedAt = deletedAt;
+		this.name = name;
+		this.user = user;
+	}
+
+	public void updateName(String name) {
+		this.name = name;
+	}
+
+	public void softDelete() {
+		this.deletedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/evenly/took/feature/card/dto/request/AddCardRequest.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/request/AddCardRequest.java
@@ -12,7 +12,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "명함을 추가하기 위한 정보", requiredMode = Schema.RequiredMode.REQUIRED)
-public record CreateCardRequest(
+public record AddCardRequest(
 	@Schema(description = "사용자 프로필 이미지", requiredMode = Schema.RequiredMode.REQUIRED)
 	MultipartFile profileImage,
 

--- a/src/main/java/com/evenly/took/feature/card/dto/request/AddFolderRequest.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/request/AddFolderRequest.java
@@ -1,0 +1,12 @@
+package com.evenly.took.feature.card.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "폴더를 추가하기 위한 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+public record AddFolderRequest(
+	@NotBlank()
+	@Schema(description = "폴더명", example = "디프만", requiredMode = Schema.RequiredMode.REQUIRED)
+	String name
+) {
+}

--- a/src/main/java/com/evenly/took/feature/card/dto/request/FixFolderRequest.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/request/FixFolderRequest.java
@@ -1,0 +1,18 @@
+package com.evenly.took.feature.card.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "폴더를 수정하기 위한 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+public record FixFolderRequest(
+
+	@NotNull()
+	@Schema(description = "폴더 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+	Long folderId,
+
+	@NotBlank()
+	@Schema(description = "폴더명", example = "디프만", requiredMode = Schema.RequiredMode.REQUIRED)
+	String name
+) {
+}

--- a/src/main/java/com/evenly/took/feature/card/dto/request/RemoveFolderRequest.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/request/RemoveFolderRequest.java
@@ -1,0 +1,13 @@
+package com.evenly.took.feature.card.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "폴더를 제거하기 위한 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+public record RemoveFolderRequest(
+
+	@NotNull()
+	@Schema(description = "폴더 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+	Long folderId
+) {
+}

--- a/src/main/java/com/evenly/took/feature/card/dto/response/FolderResponse.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/response/FolderResponse.java
@@ -1,0 +1,13 @@
+package com.evenly.took.feature.card.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "명함 폴더 응답")
+public record FolderResponse(
+	@Schema(description = "폴더 ID", example = "1")
+	Long id,
+
+	@Schema(description = "폴더명", example = "디프만")
+	String name
+) {
+}

--- a/src/main/java/com/evenly/took/feature/card/dto/response/FoldersResponse.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/response/FoldersResponse.java
@@ -1,0 +1,8 @@
+package com.evenly.took.feature.card.dto.response;
+
+import java.util.List;
+
+public record FoldersResponse(
+	List<FolderResponse> folders
+) {
+}

--- a/src/main/java/com/evenly/took/feature/card/exception/FolderErrorCode.java
+++ b/src/main/java/com/evenly/took/feature/card/exception/FolderErrorCode.java
@@ -1,0 +1,21 @@
+package com.evenly.took.feature.card.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.evenly.took.global.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FolderErrorCode implements ErrorCode {
+
+	FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "폴더를 찾을 수 없습니다."),
+	FOLDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 폴더에 대한 권한이 없습니다."),
+	FOLDER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 폴더입니다."),
+	;
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/evenly/took/feature/card/mapper/FolderMapper.java
+++ b/src/main/java/com/evenly/took/feature/card/mapper/FolderMapper.java
@@ -1,0 +1,18 @@
+package com.evenly.took.feature.card.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+
+import com.evenly.took.feature.card.domain.Folder;
+import com.evenly.took.feature.card.dto.response.FolderResponse;
+import com.evenly.took.feature.card.dto.response.FoldersResponse;
+
+@Mapper(componentModel = "spring")
+public interface FolderMapper {
+	List<FolderResponse> toFolderResponseList(List<Folder> folders);
+
+	default FoldersResponse toFoldersResponse(List<Folder> entities) {
+		return new FoldersResponse(toFolderResponseList(entities));
+	}
+}

--- a/src/main/java/com/evenly/took/global/response/SuccessResponse.java
+++ b/src/main/java/com/evenly/took/global/response/SuccessResponse.java
@@ -34,4 +34,8 @@ public class SuccessResponse<T> {
 	public static SuccessResponse<Void> created(String message) {
 		return new SuccessResponse<>(HttpStatus.CREATED, message, LocalDateTime.now(), null);
 	}
+
+	public static SuccessResponse<Void> ok(String message) {
+		return new SuccessResponse<>(HttpStatus.OK, message, LocalDateTime.now(), null);
+	}
 }


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
- #71 

## 📌 개발 이유
- 명함 폴더 생성, 조회, 수정, 삭제 기능을 작업했습니다.

## 💻 수정 사항
- 명함 폴더 관련 CRUD API 추가
- 명함 추가 Request DTO 네이밍 수정

## 🧪 테스트 방법
- Swagger 
- [POST] /api/card/folder
- [GET] /api/card/folders
- [PUT] /api/card/folder
- [DELETE] /api/card/folder

## 🎯 리뷰 포인트
테스트 케이스는 추후 작성 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 카드 생성 요청이 개선되어, 보다 명확한 데이터 구조를 사용합니다.
	- 폴더 관리 기능이 추가되어, 폴더 생성, 조회, 수정 및 삭제가 가능합니다.
	- API 문서가 업데이트되어, 기능 사용법과 오류 메시지가 더욱 명확하게 제공됩니다.
	- 성공 응답 메시지가 개선되어, 요청 처리 결과를 쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->