### PR TITLE
[Fix] 애플 인증키 파일 경로 관리되도록 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ bin/
 
 # FCM
 src/main/resources/fcm
+
+# Apple Key
+src/main/resources/apple

--- a/src/main/java/com/evenly/took/feature/auth/client/apple/AppleTokenProvider.java
+++ b/src/main/java/com/evenly/took/feature/auth/client/apple/AppleTokenProvider.java
@@ -1,10 +1,12 @@
 package com.evenly.took.feature.auth.client.apple;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.Base64;
 import java.util.Date;
 
 import org.springframework.http.HttpHeaders;
@@ -76,11 +78,9 @@ public class AppleTokenProvider {
 	}
 
 	private PrivateKey getPrivateKey() throws Exception {
-		String privateKeyContent = appleProperties.privateKey().replaceAll("-----BEGIN PRIVATE KEY-----", "")
-			.replaceAll("-----END PRIVATE KEY-----", "")
-			.replaceAll("\\s+", "");
+		Path path = Paths.get(appleProperties.privateKeyPath());
+		byte[] keyBytes = Files.readAllBytes(path);
 
-		byte[] keyBytes = Base64.getDecoder().decode(privateKeyContent);
 		PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
 		KeyFactory keyFactory = KeyFactory.getInstance("EC");
 		return keyFactory.generatePrivate(keySpec);

--- a/src/main/java/com/evenly/took/feature/auth/client/apple/AppleTokenProvider.java
+++ b/src/main/java/com/evenly/took/feature/auth/client/apple/AppleTokenProvider.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
 import java.util.Date;
 
 import org.springframework.http.HttpHeaders;
@@ -79,8 +80,14 @@ public class AppleTokenProvider {
 
 	private PrivateKey getPrivateKey() throws Exception {
 		Path path = Paths.get(appleProperties.privateKeyPath());
-		byte[] keyBytes = Files.readAllBytes(path);
+		String keyContent = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
 
+		// PEM 형식 제거
+		keyContent = keyContent.replaceAll("-----BEGIN PRIVATE KEY-----", "")
+			.replaceAll("-----END PRIVATE KEY-----", "")
+			.replaceAll("\\s+", "");
+
+		byte[] keyBytes = Base64.getDecoder().decode(keyContent);
 		PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
 		KeyFactory keyFactory = KeyFactory.getInstance("EC");
 		return keyFactory.generatePrivate(keySpec);

--- a/src/main/java/com/evenly/took/feature/auth/config/properties/AppleProperties.java
+++ b/src/main/java/com/evenly/took/feature/auth/config/properties/AppleProperties.java
@@ -8,6 +8,6 @@ public record AppleProperties(
 	String redirectUri,
 	String teamId,
 	String keyId,
-	String privateKey
+	String privateKeyPath
 ) {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,7 +51,7 @@ oauth:
     redirect-uri: ${APPLE_OAUTH_REDIRECT_URI}
     team-id: ${APPLE_OAUTH_TEAM_ID}
     key-id: ${APPLE_OAUTH_KEY_ID}
-    private-key: ${APPLE_OAUTH_PRIVATE_KEY}
+    private-key-path: ${APPLE_OAUTH_PRIVATE_KEY_PATH} # TODO prod 환경 분리
     url:
       token-url: ${APPLE_OAUTH_TOKEN_URL}
       auth-url: ${APPLE_OAUTH_AUTH_URL}

--- a/src/test/java/com/evenly/took/feature/auth/client/apple/AppleTokenProviderTest.java
+++ b/src/test/java/com/evenly/took/feature/auth/client/apple/AppleTokenProviderTest.java
@@ -34,7 +34,7 @@ class AppleTokenProviderTest extends MockTest {
 			when(mockProps.keyId()).thenReturn("test_key_id");
 			when(mockProps.teamId()).thenReturn("test_team_id");
 			when(mockProps.clientId()).thenReturn("test_client_id");
-			when(mockProps.privateKey()).thenReturn(generateMockPrivateKey());
+			when(mockProps.privateKeyPath()).thenReturn(createTempPrivateKeyFile());
 
 			AppleUrlProperties mockUrlProps = mock(AppleUrlProperties.class);
 
@@ -74,8 +74,10 @@ class AppleTokenProviderTest extends MockTest {
 		@Test
 		void 개인키_파싱_테스트() throws Exception {
 			// Arrange
+			String tempFilePath = createTempPrivateKeyFile();
+
 			AppleProperties mockProps = mock(AppleProperties.class);
-			when(mockProps.privateKey()).thenReturn(generateMockPrivateKey());
+			when(mockProps.privateKeyPath()).thenReturn(tempFilePath);
 
 			AppleUrlProperties mockUrlProps = mock(AppleUrlProperties.class);
 
@@ -126,6 +128,13 @@ class AppleTokenProviderTest extends MockTest {
 		} catch (Exception e) {
 			throw new RuntimeException("테스트용 개인키 생성 실패", e);
 		}
+	}
+
+	private String createTempPrivateKeyFile() throws Exception {
+		String privateKeyContent = generateMockPrivateKey();
+		java.nio.file.Path tempFile = java.nio.file.Files.createTempFile("apple_test_key", ".p8");
+		java.nio.file.Files.write(tempFile, privateKeyContent.getBytes());
+		return tempFile.toString();
 	}
 
 	// 프라이빗 메서드 호출을 위한 유틸 메서드


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
- #78 

## 📌 개발 이유
- 로컬과 다른 배포 환경에서는 PEM 키 형식의 환경변수를 읽는 데에 문제가 발생하였습니다.

## 💻 수정 사항
- 파일 자체를 변수로 관리 -> 파일의 경로를 변수로 관리



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 애플 OAuth 인증 구성 및 처리 방식이 업데이트되어 보안성과 안정성이 향상되었습니다.
  - 내부 자원 관리 설정이 개선되어 프로젝트 유지보수 효율이 높아졌습니다.
  - `.gitignore` 파일에 새로운 디렉토리 항목이 추가되었습니다.
  - 구성 파일에서 개인 키 참조 방식이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->