### PR TITLE
[Refactor] multipart 파일 업로드 용량 증가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,11 @@ spring:
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 swagger:
   version: 0.0.1
   server-url: ${SERVER_URL:http://localhost:8080}


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
* #89 

## 📌 개발 이유
- 카드 생성 이미지 용량 부족 

![image](https://github.com/user-attachments/assets/cdbbb2a2-16a3-4272-9875-2c5c99baedd7)

## 💻 수정 사항
- 카드 생성 이미지 용량 부족으로 default였던 multipart max-file-size(단일 파일의 최대 크기)를 1MB -> 10MB 로 
변경

<img width="677" alt="스크린샷 2025-04-02 11 36 19" src="https://github.com/user-attachments/assets/bfa156c8-22a3-473f-8ca8-00d034221330" />

## 🧪 테스트 방법
- 로컬에서 설정값을 변경하면서 swagger로 테스트

## ⛳️ 고민한 점 || 궁굼한 점
- max-request-size(요청당 최대 파일 크기)는 default인 10MB 유지할것인지 궁금합니다~

## 🎯 리뷰 포인트

## 📁 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 파일 업로드 처리 기능이 강화되었습니다. 업로드되는 개별 파일과 전체 요청에 대해 최대 10MB의 크기 제한이 적용되어 보다 안정적인 파일 전송이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->