### PR TITLE
[Refactor] 명함 상세 조회 API 응답값 추가

### DIFF
--- a/src/main/java/com/evenly/took/feature/card/api/CardController.java
+++ b/src/main/java/com/evenly/took/feature/card/api/CardController.java
@@ -132,6 +132,7 @@ public class CardController implements CardApi {
 		return SuccessResponse.of(response);
 	}
 
+	@PublicApi
 	@GetMapping("/api/card/open/detail")
 	public SuccessResponse<CardDetailResponse> getCardDetailOpen(
 		@ModelAttribute @Valid CardDetailRequest request) {

--- a/src/main/java/com/evenly/took/feature/card/application/CardService.java
+++ b/src/main/java/com/evenly/took/feature/card/application/CardService.java
@@ -125,7 +125,8 @@ public class CardService {
 				baseResponse.content(),
 				baseResponse.project(),
 				folderResponses,
-				memo
+				memo,
+				baseResponse.imagePath()
 			);
 		}
 	}

--- a/src/main/java/com/evenly/took/feature/card/dto/response/CardDetailResponse.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/response/CardDetailResponse.java
@@ -50,8 +50,10 @@ public record CardDetailResponse(
 	List<FolderResponse> folders,
 
 	@Schema(description = "한 줄 메모 (공유받은 명함 조회 시)", example = "디프만 2팀 팀장님입니다.")
-	String memo
+	String memo,
 
+	@Schema(description = "프로필 사진 경로", example = "/images/profile/user1.jpg")
+	String imagePath
 ) {
-	
+
 }

--- a/src/test/java/com/evenly/took/feature/card/api/CardIntegrationTest.java
+++ b/src/test/java/com/evenly/took/feature/card/api/CardIntegrationTest.java
@@ -1,10 +1,11 @@
 package com.evenly.took.feature.card.api;
 
-import static io.restassured.RestAssured.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.util.List;
@@ -280,6 +281,7 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 			assertThat(responseBody).contains("\"content\"");
 			assertThat(responseBody).contains("\"project\"");
 			assertThat(responseBody).contains("\"sns\"");
+			assertThat(responseBody).contains("\"imagePath\"");
 
 			assertThat(responseBody).contains("\"nickname\":\"닉네임\"");
 			assertThat(responseBody).contains("\"제목\"");


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
* #91 

## 📌 개발 이유
- 누락된 명함 상세 조회 응답값을 추가했습니다~

## 💻 수정 사항
- CardDetailResponse에 `imagePath` 추가
- `Open` 된 명함 상세 조회 API에 `@PublicApi` 가 누락되어 추가했습니다!

## 🧪  테스트 방법
- local에서 swagger로 확인
<img width="674" alt="스크린샷 2025-04-03 14 13 14" src="https://github.com/user-attachments/assets/5da7fdf6-3a0f-425e-bd34-0e09d0416473" />

- 명함 상세 조회 API 프로필 경로 추가 Integration test:
  -  [86621b1](https://github.com/depromeet/Took-BE/pull/92/commits/86621b13adc9355c01ef45d9d35f03d0943c7666) 

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 카드 상세정보 조회 기능이 개선되어, 공개 API 엔드포인트를 통해 카드 세부 정보를 확인할 수 있습니다.
	- 카드 상세조회 시 카드와 함께 이미지 경로 정보가 제공되어, 사용자에게 보다 풍부한 정보를 전달합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->