### PR TITLE
[Refactor] 받은명함 정렬을 위한 timestamp 응답 추가

### DIFF
--- a/src/main/java/com/evenly/took/feature/card/dto/response/ReceivedCardListResponse.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/response/ReceivedCardListResponse.java
@@ -3,6 +3,6 @@ package com.evenly.took.feature.card.dto.response;
 import java.util.List;
 
 public record ReceivedCardListResponse(
-	List<CardResponse> cards
+	List<ReceivedCardResponse> cards
 ) {
 }

--- a/src/main/java/com/evenly/took/feature/card/dto/response/ReceivedCardResponse.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/response/ReceivedCardResponse.java
@@ -1,0 +1,47 @@
+package com.evenly.took.feature.card.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.evenly.took.feature.card.domain.Job;
+import com.evenly.took.feature.card.domain.PreviewInfoType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ReceivedCardResponse(
+	@Schema(description = "명함 ID", example = "1")
+	Long id,
+
+	@Schema(description = "명함 받은 시간", example = "2025-03-14 03:03:04.374273")
+	LocalDateTime receivedAt,
+
+	@Schema(description = "명함용 이름", example = "홍길동")
+	String nickname,
+
+	@Schema(description = "소속 정보 (nullable)", example = "ABC 회사")
+	String organization,
+
+	@Schema(description = "직군", example = "DEVELOPER")
+	Job job,
+
+	@Schema(description = "세부 직군", example = "백엔드 개발자")
+	String detailJob,
+
+	@Schema(description = "한줄 소개", example = "백엔드 개발을 좋아하는 개발자입니다")
+	String summary,
+
+	@Schema(description = "관심 도메인", example = "[\"웹\", \"모바일\", \"클라우드\"]")
+	List<String> interestDomain,
+
+	@Schema(description = "썸네일 대표 정보 타입", example = "PROJECT")
+	PreviewInfoType previewInfoType,
+
+	@Schema(description = "대표 정보에 따른 상세 내용")
+	PreviewInfoResponse previewInfo,
+
+	@Schema(description = "프로필 사진 url", example = "https://s3/images/profile/user1.jpg")
+	String imagePath
+) {
+}

--- a/src/main/java/com/evenly/took/feature/card/mapper/CardMapper.java
+++ b/src/main/java/com/evenly/took/feature/card/mapper/CardMapper.java
@@ -9,6 +9,7 @@ import org.mapstruct.Named;
 
 import com.evenly.took.feature.card.domain.Card;
 import com.evenly.took.feature.card.domain.PreviewInfoType;
+import com.evenly.took.feature.card.domain.ReceivedCard;
 import com.evenly.took.feature.card.domain.vo.Content;
 import com.evenly.took.feature.card.domain.vo.Project;
 import com.evenly.took.feature.card.domain.vo.SNS;
@@ -19,6 +20,7 @@ import com.evenly.took.feature.card.dto.response.MyCardListResponse;
 import com.evenly.took.feature.card.dto.response.PreviewInfoResponse;
 import com.evenly.took.feature.card.dto.response.ProjectResponse;
 import com.evenly.took.feature.card.dto.response.ReceivedCardListResponse;
+import com.evenly.took.feature.card.dto.response.ReceivedCardResponse;
 import com.evenly.took.feature.card.dto.response.SNSResponse;
 
 @Mapper(componentModel = "spring", imports = {Optional.class})
@@ -36,8 +38,27 @@ public interface CardMapper {
 		return new MyCardListResponse(toCardResponseList(cards));
 	}
 
-	default ReceivedCardListResponse toCardListResponse(List<Card> cards) {
-		return new ReceivedCardListResponse(toCardResponseList(cards));
+	default ReceivedCardListResponse toReceivedCardListResponse(List<ReceivedCard> receivedCards) {
+		List<ReceivedCardResponse> responses = receivedCards.stream()
+			.map(receivedCard -> {
+				Card card = receivedCard.getCard();
+				return new ReceivedCardResponse(
+					card.getId(),
+					receivedCard.getCreatedAt(),
+					card.getNickname(),
+					card.getOrganization(),
+					card.getCareer() != null ? card.getCareer().getJob() : null,
+					card.getCareer() != null ? card.getCareer().getDetailJobEn() : null,
+					card.getSummary(),
+					card.getInterestDomain(),
+					card.getPreviewInfo(),
+					toPreviewInfoResponse(card),
+					card.getImagePath()
+				);
+			})
+			.toList();
+
+		return new ReceivedCardListResponse(responses);
 	}
 
 	@Named("toPreviewInfoResponse")


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
* #100 

## 📌 개발 이유
- 받은명함 최신공유순으로 정렬

## 💻 수정 사항
- timestamp(receivedAt) 응답 필드 추가

## 🧪 테스트 방법
- 기존 로직과 응답값이 같게 오는것 확인, test code 응답

## ⛳️ 고민한 점 || 궁굼한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 수신 카드의 상세 정보를 제공하는 새로운 응답 객체가 추가되었습니다.
- **리팩토링**
	- 카드 생성 과정에서 제한 체크 로직이 제거되어, 카드 추가 절차가 개선되었습니다.
	- 수신 카드 목록 처리 로직이 간소화되어, 카드 정보 전달 및 이미지 경로 업데이트가 보다 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->