### PR TITLE
[Feat] 대표 명함 설정 및 조회

### DIFF
--- a/src/main/java/com/evenly/took/feature/card/api/CardApi.java
+++ b/src/main/java/com/evenly/took/feature/card/api/CardApi.java
@@ -244,4 +244,22 @@ public interface CardApi {
 		User user,
 		FixReceivedCardRequest request
 	);
+
+	@Operation(
+		summary = "대표 명함 설정",
+		description = "사용자가 소유한 명함 중 하나를 대표 명함으로 설정합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "대표 명함 설정 성공"),
+		@ApiResponse(responseCode = "404", description = "명함을 찾을 수 없음",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "403", description = "명함 소유자가 아님",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	SuccessResponse<Void> setPrimaryCard(
+		@Parameter(description = "로그인 사용자", hidden = true)
+		User user,
+
+		@Parameter(description = "대표로 지정할 명함 ID", required = true)
+		Long cardId
+	);
 }

--- a/src/main/java/com/evenly/took/feature/card/api/CardController.java
+++ b/src/main/java/com/evenly/took/feature/card/api/CardController.java
@@ -191,4 +191,13 @@ public class CardController implements CardApi {
 		cardService.updateReceivedCard(user, request);
 		return SuccessResponse.ok("명함 업데이트 성공");
 	}
+
+	@PostMapping("/api/card/{id}/primary")
+	public SuccessResponse<Void> setPrimaryCard(
+		@LoginUser User user,
+		@PathVariable("id") Long cardId
+	) {
+		cardService.setPrimaryCard(user.getId(), cardId);
+		return SuccessResponse.ok("대표 명함 설정 성공");
+	}
 }

--- a/src/main/java/com/evenly/took/feature/card/application/CardService.java
+++ b/src/main/java/com/evenly/took/feature/card/application/CardService.java
@@ -80,7 +80,7 @@ public class CardService {
 
 	@Transactional(readOnly = true)
 	public MyCardListResponse findUserCardList(Long userId) {
-		List<Card> cards = cardRepository.findAllByUserIdAndDeletedAtIsNull(userId);
+		List<Card> cards = cardRepository.findAllByUserIdAndDeletedAtIsNullOrderByIsPrimaryDesc(userId);
 
 		cards.forEach(this::updatePresignedImagePath);
 

--- a/src/main/java/com/evenly/took/feature/card/application/CardService.java
+++ b/src/main/java/com/evenly/took/feature/card/application/CardService.java
@@ -191,11 +191,12 @@ public class CardService {
 			.isPrimary(isCreatingFirstCard(currentCardCount))
 			.build();
 
+		System.out.println(newCard.isPrimary());
 		cardRepository.save(newCard);
 	}
 
 	private boolean isCreatingFirstCard(Long currentCardCount) {
-		return cardRepository.countByUserIdAndDeletedAtIsNull(currentCardCount) == 0;
+		return currentCardCount == 0;
 	}
 
 	@Transactional

--- a/src/main/java/com/evenly/took/feature/card/dao/CardRepository.java
+++ b/src/main/java/com/evenly/took/feature/card/dao/CardRepository.java
@@ -21,6 +21,14 @@ public interface CardRepository extends JpaRepository<Card, Long> {
 
 	List<Card> findAllByUserIdAndDeletedAtIsNull(Long userId);
 
+	@Query(value = """
+		SELECT * FROM cards
+		WHERE user_id = :userId
+		  AND deleted_at IS NULL
+		ORDER BY is_primary DESC, id ASC
+		""", nativeQuery = true)
+	List<Card> findAllByUserIdAndDeletedAtIsNullOrderByIsPrimaryDesc(@Param("userId") Long userId);
+
 	Optional<Card> findByIdAndDeletedAtIsNull(Long cardId);
 
 	@Modifying(clearAutomatically = true)

--- a/src/main/java/com/evenly/took/feature/card/domain/Card.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/Card.java
@@ -92,10 +92,13 @@ public class Card extends BaseTimeEntity {
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
 
+	@Column(name = "isPrimary")
+	private boolean isPrimary;
+
 	@Builder
-	public Card(Career career, List<Content> content, String hobby, String imagePath,
-		List<String> interestDomain, LocalDateTime deletedAt, String news, String nickname, String organization,
-		PreviewInfoType previewInfo, List<Project> project, String region, List<SNS> sns, String summary, User user) {
+	public Card(Career career, List<Content> content, String hobby, String imagePath, List<String> interestDomain,
+		LocalDateTime deletedAt, String news, String nickname, String organization, PreviewInfoType previewInfo,
+		List<Project> project, String region, List<SNS> sns, String summary, User user, boolean isPrimary) {
 		this.career = career;
 		this.content = content;
 		this.hobby = hobby;
@@ -111,6 +114,7 @@ public class Card extends BaseTimeEntity {
 		this.summary = summary;
 		this.user = user;
 		this.interestDomain = interestDomain;
+		this.isPrimary = isPrimary;
 	}
 
 	public void setImageLink(String signedImageLink) {
@@ -126,5 +130,9 @@ public class Card extends BaseTimeEntity {
 		if (!userId.equals(this.user.getId())) {
 			throw new TookException(CardErrorCode.INVALID_CARD_OWNER);
 		}
+	}
+
+	public void changePrimaryCard(boolean isPrimary) {
+		this.isPrimary = isPrimary;
 	}
 }

--- a/src/main/java/com/evenly/took/feature/card/domain/Card.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/Card.java
@@ -92,7 +92,7 @@ public class Card extends BaseTimeEntity {
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
 
-	@Column(name = "isPrimary")
+	@Column(name = "is_primary")
 	private boolean isPrimary;
 
 	@Builder

--- a/src/main/java/com/evenly/took/feature/card/dto/response/CardResponse.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/response/CardResponse.java
@@ -38,6 +38,9 @@ public record CardResponse(
 	PreviewInfoResponse previewInfo,
 
 	@Schema(description = "프로필 사진 url", example = "https://s3/images/profile/user1.jpg")
-	String imagePath
+	String imagePath,
+
+	@Schema(description = "대표 명함인지 확인", example = "true")
+	boolean isPrimary
 ) {
 }

--- a/src/main/java/com/evenly/took/feature/card/mapper/CardMapper.java
+++ b/src/main/java/com/evenly/took/feature/card/mapper/CardMapper.java
@@ -30,6 +30,7 @@ public interface CardMapper {
 	@Mapping(source = "career.job", target = "job")
 	@Mapping(source = "career.detailJobEn", target = "detailJob")
 	@Mapping(source = "previewInfo", target = "previewInfoType")
+	@Mapping(source = "primary", target = "isPrimary")
 	CardResponse toCardResponse(Card card);
 
 	List<CardResponse> toCardResponseList(List<Card> cards);

--- a/src/test/java/com/evenly/took/feature/card/api/CardIntegrationTest.java
+++ b/src/test/java/com/evenly/took/feature/card/api/CardIntegrationTest.java
@@ -39,6 +39,7 @@ import com.evenly.took.feature.card.dto.request.RemoveFolderRequest;
 import com.evenly.took.feature.card.dto.request.RemoveReceivedCardsRequest;
 import com.evenly.took.feature.card.dto.request.SetReceivedCardsFolderRequest;
 import com.evenly.took.feature.card.dto.response.CardResponse;
+import com.evenly.took.feature.card.dto.response.MyCardListResponse;
 import com.evenly.took.feature.card.dto.response.ScrapResponse;
 import com.evenly.took.feature.card.exception.CardErrorCode;
 import com.evenly.took.feature.card.exception.FolderErrorCode;
@@ -1407,53 +1408,55 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 		@Test
 		void 대표_명함이_항상_가장_먼저_조회된다_중간() {
 			// given
-			Card card1 = cardFixture.creator().user(mockUser).nickname("후보1").isPrimary(false).create();
-			Card card2 = cardFixture.creator().user(mockUser).nickname("대표").isPrimary(true).create();
-			Card card3 = cardFixture.creator().user(mockUser).nickname("후보2").isPrimary(false).create();
+			cardFixture.creator().user(mockUser).nickname("후보1").isPrimary(false).create();
+			cardFixture.creator().user(mockUser).nickname("대표").isPrimary(true).create();
+			cardFixture.creator().user(mockUser).nickname("후보2").isPrimary(false).create();
 
 			// when
-			ExtractableResponse<Response> response = given()
+			MyCardListResponse response = given()
 				.contentType(ContentType.JSON)
 				.header("Authorization", authToken)
 				.when()
 				.get("/api/card/my")
 				.then()
 				.statusCode(HttpStatus.OK.value())
-				.extract();
+				.extract()
+				.jsonPath()
+				.getObject("data", MyCardListResponse.class);
 
 			// then
-			Map<String, Object> responseMap = response.as(Map.class);
-			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
-			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
-
-			assertThat(cards).hasSize(3);
-			assertThat(cards.get(0).get("nickname")).isEqualTo("대표");
+			assertThat(response.cards()).hasSize(3);
+			assertThat(response.cards().get(0).nickname()).isEqualTo("대표");
+			assertThat(response.cards().get(0).isPrimary()).isEqualTo(true);
+			assertThat(response.cards().get(1).isPrimary()).isEqualTo(false);
+			assertThat(response.cards().get(2).isPrimary()).isEqualTo(false);
 		}
 
 		@Test
 		void 대표_명함이_항상_가장_먼저_조회된다_끝() {
 			// given
-			Card card1 = cardFixture.creator().user(mockUser).nickname("후보1").isPrimary(false).create();
-			Card card2 = cardFixture.creator().user(mockUser).nickname("후보2").isPrimary(false).create();
-			Card card3 = cardFixture.creator().user(mockUser).nickname("대표").isPrimary(true).create();
+			cardFixture.creator().user(mockUser).nickname("후보1").isPrimary(false).create();
+			cardFixture.creator().user(mockUser).nickname("후보2").isPrimary(false).create();
+			cardFixture.creator().user(mockUser).nickname("대표").isPrimary(true).create();
 
 			// when
-			ExtractableResponse<Response> response = given()
+			MyCardListResponse response = given()
 				.contentType(ContentType.JSON)
 				.header("Authorization", authToken)
 				.when()
 				.get("/api/card/my")
 				.then()
 				.statusCode(HttpStatus.OK.value())
-				.extract();
+				.extract()
+				.jsonPath()
+				.getObject("data", MyCardListResponse.class);
 
 			// then
-			Map<String, Object> responseMap = response.as(Map.class);
-			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
-			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
-
-			assertThat(cards).hasSize(3);
-			assertThat(cards.get(0).get("nickname")).isEqualTo("대표");
+			assertThat(response.cards()).hasSize(3);
+			assertThat(response.cards().get(0).nickname()).isEqualTo("대표");
+			assertThat(response.cards().get(0).isPrimary()).isEqualTo(true);
+			assertThat(response.cards().get(1).isPrimary()).isEqualTo(false);
+			assertThat(response.cards().get(2).isPrimary()).isEqualTo(false);
 		}
 	}
 }

--- a/src/test/java/com/evenly/took/feature/card/api/CardIntegrationTest.java
+++ b/src/test/java/com/evenly/took/feature/card/api/CardIntegrationTest.java
@@ -1400,4 +1400,60 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 			assertThat(remaining).isEmpty();
 		}
 	}
+
+	@Nested
+	class 명함_조회_우선순위 {
+
+		@Test
+		void 대표_명함이_항상_가장_먼저_조회된다_중간() {
+			// given
+			Card card1 = cardFixture.creator().user(mockUser).nickname("후보1").isPrimary(false).create();
+			Card card2 = cardFixture.creator().user(mockUser).nickname("대표").isPrimary(true).create();
+			Card card3 = cardFixture.creator().user(mockUser).nickname("후보2").isPrimary(false).create();
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(ContentType.JSON)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/my")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).hasSize(3);
+			assertThat(cards.get(0).get("nickname")).isEqualTo("대표");
+		}
+
+		@Test
+		void 대표_명함이_항상_가장_먼저_조회된다_끝() {
+			// given
+			Card card1 = cardFixture.creator().user(mockUser).nickname("후보1").isPrimary(false).create();
+			Card card2 = cardFixture.creator().user(mockUser).nickname("후보2").isPrimary(false).create();
+			Card card3 = cardFixture.creator().user(mockUser).nickname("대표").isPrimary(true).create();
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(ContentType.JSON)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/my")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).hasSize(3);
+			assertThat(cards.get(0).get("nickname")).isEqualTo("대표");
+		}
+	}
 }

--- a/src/test/java/com/evenly/took/feature/card/application/CardServiceTest.java
+++ b/src/test/java/com/evenly/took/feature/card/application/CardServiceTest.java
@@ -1,9 +1,11 @@
 package com.evenly.took.feature.card.application;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -11,6 +13,7 @@ import com.evenly.took.feature.card.dao.CardRepository;
 import com.evenly.took.feature.card.domain.Card;
 import com.evenly.took.feature.card.domain.Job;
 import com.evenly.took.feature.card.domain.PreviewInfoType;
+import com.evenly.took.feature.card.dto.request.AddCardRequest;
 import com.evenly.took.feature.card.dto.request.CardDetailRequest;
 import com.evenly.took.feature.card.dto.response.CardDetailResponse;
 import com.evenly.took.feature.card.dto.response.CareersResponse;
@@ -156,4 +159,160 @@ public class CardServiceTest extends ServiceTest {
 	//
 	// 	assertThat(exception.getErrorCode()).isEqualTo(CardErrorCode.CARD_LIMIT_EXCEEDED);
 	// }
+
+	@Nested
+	class 대표_명함_기능 {
+
+		@Test
+		void 대표_명함_삭제_시_남은_명함이_대표로_지정된다() {
+			// given
+			User user = userFixture.create();
+			Card card1 = cardFixture.creator().user(user).isPrimary(true).create();
+			Card card2 = cardFixture.creator().user(user).create();
+
+			// when
+			cardService.softDeleteMyCard(user.getId(), card1.getId());
+
+			// then
+			List<Card> cards = cardRepository.findAllByUserIdAndDeletedAtIsNull(user.getId());
+			assertThat(cards).hasSize(1);
+			assertThat(cards.get(0).isPrimary()).isTrue();
+		}
+
+		@Test
+		void 특정_명함을_대표로_설정하면_다른_명함은_대표가_해제된다() {
+			// given
+			User user = userFixture.create();
+			Card card1 = cardFixture.creator().user(user).isPrimary(true).create();
+			Card card2 = cardFixture.creator().user(user).isPrimary(false).create();
+
+			// when
+			cardService.setPrimaryCard(user.getId(), card2.getId());
+
+			// then
+			Card updatedCard1 = cardRepository.findById(card1.getId()).get();
+			Card updatedCard2 = cardRepository.findById(card2.getId()).get();
+
+			assertThat(updatedCard1.isPrimary()).isFalse();
+			assertThat(updatedCard2.isPrimary()).isTrue();
+		}
+
+		@Test
+		void 최초_명함_생성시_자동으로_대표_명함으로_지정된다() {
+			// given
+			User user = userFixture.create();
+			assertThat(cardRepository.countByUserIdAndDeletedAtIsNull(user.getId())).isZero();
+
+			AddCardRequest request = new AddCardRequest(
+				null,
+				"테스트닉네임",
+				1L,
+				List.of("AI", "백엔드"),
+				"요약입니다",
+				"조직명",
+				List.of(),
+				"서울",
+				"등산",
+				"뉴스",
+				List.of(),
+				List.of(),
+				PreviewInfoType.SNS
+			);
+
+			String profileImageKey = "test-image.jpg";
+
+			// when
+			cardService.createCard(user, request, profileImageKey);
+
+			// then
+			List<Card> cards = cardRepository.findAllByUserIdAndDeletedAtIsNull(user.getId());
+			assertThat(cards).hasSize(1);
+			assertThat(cards.get(0).isPrimary()).isTrue();
+		}
+
+		@Test
+		void 기존_명함이_있을경우_새로_생성한_명함은_대표_명함이_아니다() {
+			// given
+			User user = userFixture.create();
+			cardFixture.creator().user(user).isPrimary(true).create();
+
+			AddCardRequest request = new AddCardRequest(
+				null,
+				"테스트닉네임",
+				1L,
+				List.of("AI", "백엔드"),
+				"요약입니다",
+				"조직명",
+				List.of(),
+				"서울",
+				"등산",
+				"뉴스",
+				List.of(),
+				List.of(),
+				PreviewInfoType.SNS
+			);
+			String profileImageKey = "test-image-2.jpg";
+
+			// when
+			cardService.createCard(user, request, profileImageKey);
+
+			// then
+			List<Card> cards = cardRepository.findAllByUserIdAndDeletedAtIsNull(user.getId());
+			assertThat(cards).hasSize(2);
+			assertThat(cards.stream().filter(Card::isPrimary)).hasSize(1);
+		}
+
+		@Test
+		void 명함_생성_후_대표_삭제_시_다른_명함이_대표로_지정된다() {
+			// given
+			User user = userFixture.create();
+			String profileImageKey = "test-image.jpg";
+
+			AddCardRequest request1 = new AddCardRequest(
+				null,
+				"테스트닉네임1",
+				1L,
+				List.of("AI", "백엔드"),
+				"요약입니다",
+				"조직명",
+				List.of(),
+				"서울",
+				"등산",
+				"뉴스",
+				List.of(),
+				List.of(),
+				PreviewInfoType.SNS
+			);
+
+			cardService.createCard(user, request1, profileImageKey);
+
+			AddCardRequest request2 = new AddCardRequest(
+				null,
+				"일반명함",
+				1L,
+				List.of("프론트"),
+				"요약2",
+				"회사2",
+				List.of(),
+				"부산",
+				"독서",
+				"뉴스",
+				List.of(),
+				List.of(),
+				PreviewInfoType.SNS
+			);
+			cardService.createCard(user, request2, profileImageKey);
+
+			List<Card> cards = cardRepository.findAllByUserIdAndDeletedAtIsNull(user.getId());
+			Card primaryCard = cards.stream().filter(Card::isPrimary).findFirst().orElseThrow();
+			Card nonPrimaryCard = cards.stream().filter(c -> !c.isPrimary()).findFirst().orElseThrow();
+
+			// when
+			cardService.softDeleteMyCard(user.getId(), primaryCard.getId());
+
+			// then
+			Card updated = cardRepository.findById(nonPrimaryCard.getId()).orElseThrow();
+			assertThat(updated.isPrimary()).isTrue();
+		}
+	}
 }

--- a/src/test/java/com/evenly/took/global/domain/CardBase.java
+++ b/src/test/java/com/evenly/took/global/domain/CardBase.java
@@ -30,6 +30,7 @@ public abstract class CardBase {
 	static List<Content> DEFAULT_CONTENTS = List.of(new Content("제목", "링크", "이미지", "설명"));
 	static List<Project> DEFAULT_PROJECTS = List.of(new Project("제목", "링크", "이미지", "설명"));
 	static LocalDateTime DEFAULT_DELETED_AT = null;
+	static boolean DEFAULT_IS_PRIMARY = false;
 
 	Long id;
 	User user;
@@ -47,6 +48,7 @@ public abstract class CardBase {
 	List<Content> contents;
 	List<Project> projects;
 	LocalDateTime deletedAt;
+	boolean isPrimary;
 
 	protected CardBase() {
 		init();
@@ -69,6 +71,7 @@ public abstract class CardBase {
 		this.contents = DEFAULT_CONTENTS;
 		this.projects = DEFAULT_PROJECTS;
 		this.deletedAt = DEFAULT_DELETED_AT;
+		this.isPrimary = DEFAULT_IS_PRIMARY;
 	}
 
 	public CardBase id(Long id) {
@@ -148,6 +151,11 @@ public abstract class CardBase {
 
 	public CardBase deletedAt(LocalDateTime deletedAt) {
 		this.deletedAt = deletedAt;
+		return this;
+	}
+
+	public CardBase isPrimary(boolean isPrimary) {
+		this.isPrimary = isPrimary;
 		return this;
 	}
 

--- a/src/test/java/com/evenly/took/global/domain/CardFixture.java
+++ b/src/test/java/com/evenly/took/global/domain/CardFixture.java
@@ -43,6 +43,7 @@ public class CardFixture extends CardBase {
 			.news(news)
 			.content(contents)
 			.project(projects)
+			.isPrimary(isPrimary)
 			.build();
 		return cardRepository.save(card);
 	}


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
* #110 

## 📌 개발 이유
- 대표 명함 설정
- 자신의 명함 조회시 대표 명함이 먼저 조회도록

## 💻 수정 사항
- `/api/card/{id}/primary` POST API 추가
  - `CardService#setPrimaryCard(Long userId, Long cardId)` 호출
  - 기존 대표 명함 해제 후 요청 명함을 대표로 설정
- `CardApi` 인터페이스 명세에 메서드 추가
- Controller (`CardController`)에 API 엔드포인트 구현

## 🧪 테스트 방법

No. | 테스트 이름 | 설명
-- | -- | --
1 | 대표_명함이_항상_가장_먼저_조회된다_처음 | 대표 명함이 첫 번째일 때 조회 순서를 검증
2 | 대표_명함이_항상_가장_먼저_조회된다_중간 | 대표 명함이 중간에 생성되었을 때도 첫 번째로 조회되는지 검증
3 | 대표_명함이_항상_가장_먼저_조회된다_끝 | 대표 명함이 가장 마지막에 생성되었어도 조회 결과에서는 제일 앞에 오는지 검증
4 | 대표_명함이_하나뿐인_경우_정상_조회된다 | 명함이 하나뿐이고, 그 명함이 대표인 경우 정상적으로 조회되는지 검증
5 | 대표_명함이_없는_경우_조회_결과는_기본_정렬 | 모든 명함이 isPrimary = false일 때, 조회 순서가 ID 기준 정렬인지 확인
6 | 대표_명함이_삭제된_경우_다른_명함이_대표로_승격된다 | 대표 명함을 삭제하면 다른 명함 중 하나가 대표가 되어 조회 순서가 바뀌는지 검증


## ⛳️ 고민한 점 || 궁금한 점

## 🎯 리뷰 포인트

## 📁 레퍼런스


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 카드 중 하나를 기본 카드(대표 카드)로 지정할 수 있는 기능을 추가했습니다.
  - 첫 카드 생성 시 자동으로 기본 카드가 지정되며, 삭제나 변경 시 다른 카드가 기본으로 할당됩니다.
  - 카드 목록 조회 시 기본 카드가 우선적으로 표시됩니다.

- **테스트**
  - 기본 카드 설정 및 변경 기능의 안정성을 검증하기 위한 다양한 테스트 시나리오가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->