### PR TITLE
[Feat] 명함 수정 API 구현

### DIFF
--- a/src/main/java/com/evenly/took/feature/card/api/CardApi.java
+++ b/src/main/java/com/evenly/took/feature/card/api/CardApi.java
@@ -8,6 +8,7 @@ import com.evenly.took.feature.card.dto.request.AddCardRequest;
 import com.evenly.took.feature.card.dto.request.AddFolderRequest;
 import com.evenly.took.feature.card.dto.request.CardDetailRequest;
 import com.evenly.took.feature.card.dto.request.CardRequest;
+import com.evenly.took.feature.card.dto.request.FixCardRequest;
 import com.evenly.took.feature.card.dto.request.FixFolderRequest;
 import com.evenly.took.feature.card.dto.request.FixReceivedCardRequest;
 import com.evenly.took.feature.card.dto.request.LinkRequest;
@@ -243,5 +244,22 @@ public interface CardApi {
 	SuccessResponse<Void> fixReceivedCard(
 		User user,
 		FixReceivedCardRequest request
+	);
+
+	@Operation(
+		summary = "명함 수정",
+		description = "내 명함을 수정합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "내 명함 수정 성공"),
+		@ApiResponse(responseCode = "404", description = "내 명함을 찾을 수 없음",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "403", description = "권한이 없음",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	SuccessResponse<Void> fixCard(
+		User user,
+		FixCardRequest request,
+		@Parameter(hidden = true)
+		MultipartFile profileImage
 	);
 }

--- a/src/main/java/com/evenly/took/feature/card/api/CardController.java
+++ b/src/main/java/com/evenly/took/feature/card/api/CardController.java
@@ -21,6 +21,7 @@ import com.evenly.took.feature.card.dto.request.AddCardRequest;
 import com.evenly.took.feature.card.dto.request.AddFolderRequest;
 import com.evenly.took.feature.card.dto.request.CardDetailRequest;
 import com.evenly.took.feature.card.dto.request.CardRequest;
+import com.evenly.took.feature.card.dto.request.FixCardRequest;
 import com.evenly.took.feature.card.dto.request.FixFolderRequest;
 import com.evenly.took.feature.card.dto.request.FixReceivedCardRequest;
 import com.evenly.took.feature.card.dto.request.LinkRequest;
@@ -190,5 +191,22 @@ public class CardController implements CardApi {
 	) {
 		cardService.updateReceivedCard(user, request);
 		return SuccessResponse.ok("명함 업데이트 성공");
+	}
+
+	@PutMapping(value = "/api/card", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public SuccessResponse<Void> fixCard(
+		@LoginUser User user,
+		@ModelAttribute FixCardRequest request,
+		@RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
+
+		Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+		Set<ConstraintViolation<FixCardRequest>> violations = validator.validate(request);
+
+		if (!violations.isEmpty()) {
+			throw new ConstraintViolationException("요청 필드 유효성 검사 실패", violations);
+		}
+
+		cardService.updateCard(user, request, profileImage);
+		return SuccessResponse.ok("내 명함 수정 성공");
 	}
 }

--- a/src/main/java/com/evenly/took/feature/card/application/CardService.java
+++ b/src/main/java/com/evenly/took/feature/card/application/CardService.java
@@ -3,6 +3,7 @@ package com.evenly.took.feature.card.application;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -26,6 +27,7 @@ import com.evenly.took.feature.card.dto.request.AddCardRequest;
 import com.evenly.took.feature.card.dto.request.AddFolderRequest;
 import com.evenly.took.feature.card.dto.request.CardDetailRequest;
 import com.evenly.took.feature.card.dto.request.CardRequest;
+import com.evenly.took.feature.card.dto.request.FixCardRequest;
 import com.evenly.took.feature.card.dto.request.FixFolderRequest;
 import com.evenly.took.feature.card.dto.request.FixReceivedCardRequest;
 import com.evenly.took.feature.card.dto.request.LinkRequest;
@@ -99,8 +101,6 @@ public class CardService {
 					request.cardId())
 				.orElseThrow(() -> new TookException(CardErrorCode.CARD_NOT_FOUND));
 
-			Card card = updatePresignedImagePath(receivedCard.getCard());
-
 			List<ReceivedCardFolder> folderRelations =
 				receivedCardFolderRepository.findAllByReceivedCardIdAndDeletedAtIsNull(receivedCard.getId());
 
@@ -113,7 +113,8 @@ public class CardService {
 
 			String memo = receivedCard.getMemo();
 
-			CardDetailResponse baseResponse = cardMapper.toCardDetailResponse(card);
+			CardDetailResponse baseResponse = cardMapper.toCardDetailResponse(
+				updatePresignedImagePath(receivedCard.getCard()));
 
 			return new CardDetailResponse(
 				baseResponse.nickname(),
@@ -316,6 +317,53 @@ public class CardService {
 	}
 
 	@Transactional
+	public void updateCard(User user, FixCardRequest request, MultipartFile profileImage) {
+		Card card = findCardOrThrow(request.cardId());
+
+		if (!Objects.equals(card.getUser().getId(), user.getId())) {
+			throw new TookException(CardErrorCode.INVALID_CARD_OWNER);
+		}
+
+		handleImageUpdate(card, request.profileImage(), request.isImageRemoved());
+
+		card.setNickname(request.nickname());
+		card.setSummary(request.summary());
+		card.setCareer(Career.toEntity(request.detailJobId()));
+		card.setOrganization(request.organization());
+		card.setInterestDomain(request.interestDomain());
+		card.setRegion(request.region());
+		card.setHobby(request.hobby());
+		card.setNews(request.news());
+		card.setPreviewInfo(request.previewInfoType());
+		card.setSns(snsMapper.toEntity(request.sns()));
+		card.setContent(contentMapper.toEntity(request.content()));
+		card.setProject(projectMapper.toEntity(request.project()));
+	}
+
+	private void handleImageUpdate(Card card, MultipartFile newProfileImage, Boolean isImageRemoved) {
+		String oldImageKey = card.getImagePath();
+
+		String newImageKey = uploadProfileImage(newProfileImage);
+		// Case 1: 새 이미지 업로드된 경우
+		if (newProfileImage != null && !newProfileImage.isEmpty()) {
+			if (oldImageKey != null && !oldImageKey.isEmpty()) {
+				s3Service.deleteFile(oldImageKey);
+			}
+			card.setImageLink(newImageKey);
+		}
+		// Case 2: 새 이미지 없고, 기존 이미지 유지 신호도 없는 경우 (기존 이미지 삭제)
+		else if (isImageRemoved) {
+			// 기존 이미지 S3에서 삭제 (있었다면)
+			if (oldImageKey != null && !oldImageKey.isEmpty()) {
+				s3Service.deleteFile(oldImageKey);
+			}
+			card.setImageLink(newImageKey); // 기본 이미지 Key
+		}
+		// Case 3: 새 이미지 없고, 기존 이미지 유지 신호(originImageKey)가 있는 경우
+		// -> 아무 작업도 하지 않음 (card.imagePath는 변경되지 않음)
+	}
+
+	@Transactional
 	public void softDeleteAllCards(Long userId, LocalDateTime now) {
 		cardRepository.softDeleteAllByUserId(userId, now);
 	}
@@ -338,7 +386,7 @@ public class CardService {
 	@Transactional
 	public void softDeleteMyCard(Long userId, Long cardId) {
 		Card card = cardRepository.findById(cardId)
-			.orElseThrow(() -> new TookException(CardErrorCode.CARD_NOT_FOUND));
+			.orElseThrow(() -> new TookException(CardErrorCode.INVALID_CARD_OWNER));
 		card.softDelete(userId);
 	}
 

--- a/src/main/java/com/evenly/took/feature/card/domain/Card.java
+++ b/src/main/java/com/evenly/took/feature/card/domain/Card.java
@@ -29,11 +29,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "cards")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Setter
 public class Card extends BaseTimeEntity {
 
 	@Id

--- a/src/main/java/com/evenly/took/feature/card/dto/request/FixCardRequest.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/request/FixCardRequest.java
@@ -1,0 +1,66 @@
+package com.evenly.took.feature.card.dto.request;
+
+import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.evenly.took.feature.card.domain.PreviewInfoType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "명함을 수정하기 위한 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+public record FixCardRequest(
+
+	@Schema(description = "명함 ID", requiredMode = Schema.RequiredMode.REQUIRED)
+	Long cardId,
+
+	@Schema(description = "사용자 프로필 이미지", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	MultipartFile profileImage,
+
+	@Schema(description = "사용자 프로필 이미지 제거 여부 (기존 이미지를 유지하는지, 삭제하는지 구분 용도)", requiredMode = Schema.RequiredMode.REQUIRED)
+	Boolean isImageRemoved,
+
+	@NotBlank()
+	@Schema(description = "이름", example = "윤장원", requiredMode = Schema.RequiredMode.REQUIRED)
+	String nickname,
+
+	@NotNull()
+	@Schema(description = "세부직군 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+	Long detailJobId,
+
+	@NotEmpty()
+	@Schema(description = "관심 도메인", example = "[\"웹\", \"모바일\", \"클라우드\"]", requiredMode = Schema.RequiredMode.REQUIRED)
+	List<String> interestDomain,
+
+	@NotBlank()
+	@Schema(description = "한 줄 소개", example = "백엔드 개발을 좋아하는 개발자입니다", requiredMode = Schema.RequiredMode.REQUIRED)
+	String summary,
+
+	@Schema(description = "소속 정보", example = "ABC 회사", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	String organization,
+
+	@Schema(description = "SNS 정보", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	List<SNSRequest> sns,
+
+	@Schema(description = "활동 지역", example = "서울 강남구", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	String region,
+
+	@Schema(description = "취미 정보", example = "등산, 독서", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	String hobby,
+
+	@Schema(description = "최근 소식", example = "최근 블로그 포스팅 시작했습니다", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	String news,
+
+	@Schema(description = "작성한 글 정보", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	List<ContentRequest> content,
+
+	@Schema(description = "프로젝트 정보", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	List<ProjectRequest> project,
+
+	@Schema(description = "대표 썸네일 타입", example = "SNS", requiredMode = Schema.RequiredMode.REQUIRED)
+	PreviewInfoType previewInfoType
+) {
+}

--- a/src/main/java/com/evenly/took/feature/card/exception/CardErrorCode.java
+++ b/src/main/java/com/evenly/took/feature/card/exception/CardErrorCode.java
@@ -20,7 +20,7 @@ public enum CardErrorCode implements ErrorCode {
 	RECEIVED_CARD_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 수신 명함에 대한 권한이 없습니다."),
 	RECEIVED_CARD_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 수신 명함입니다."),
 	INVALID_CRAWL_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 크롤링 링크입니다."),
-	INVALID_CARD_OWNER(HttpStatus.BAD_REQUEST, "자신이 소유한 카드만 삭제할 수 있습니다."),
+	INVALID_CARD_OWNER(HttpStatus.BAD_REQUEST, "자신이 소유한 카드만 수정할 수 있습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/evenly/took/global/aws/s3/S3ServiceImpl.java
+++ b/src/main/java/com/evenly/took/global/aws/s3/S3ServiceImpl.java
@@ -82,11 +82,19 @@ public class S3ServiceImpl implements S3Service {
 	}
 
 	public String uploadFile(MultipartFile file, String path) {
-		String fileName = createFileName(file.getOriginalFilename());
-		String key = awsProperties.s3().env() + path + fileName;
-
-		if (fileName.contains("default") || file.isEmpty()) {
+		String key;
+		String fileName;
+		if (file == null || file.isEmpty()) {
 			key = awsProperties.s3().baseImage();
+			return key;
+		} else {
+			fileName = createFileName(file.getOriginalFilename());
+			if (fileName.contains("default")) {
+				key = awsProperties.s3().baseImage();
+				return key;
+			} else {
+				key = awsProperties.s3().env() + path + fileName;
+			}
 		}
 
 		String bucket = awsProperties.s3().bucket();

--- a/src/test/java/com/evenly/took/global/config/testcontainers/S3TestConfig.java
+++ b/src/test/java/com/evenly/took/global/config/testcontainers/S3TestConfig.java
@@ -25,6 +25,7 @@ public class S3TestConfig {
 	private LocalStackContainer localstack;
 	private final String TEST_BUCKET = "test-bucket";
 	private final String TEST_ENV = "test-env/";
+	private final String TEST_IMAGE_KEY = "base-image.png";
 
 	@PostConstruct
 	public void startLocalStack() {
@@ -89,7 +90,8 @@ public class S3TestConfig {
 	public AwsS3Properties testAwsS3Properties() {
 		return new AwsS3Properties(
 			TEST_BUCKET,
-			TEST_ENV
+			TEST_ENV,
+			TEST_IMAGE_KEY
 		);
 	}
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -48,3 +48,7 @@ fcm:
 #  rate-limit:
 #    max-requests: 10 # 시간 윈도우당 최대 요청 수
 #    window-seconds: 10 # 시간 윈도우(초)
+
+aws:
+  s3:
+    base-image: 'baseKey.png'


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
- #106 

## 📌 개발 이유
기존 소유 명함을 수정 하기 위한 API 구현 (multipart/form-data)

## 💻 수정 사항
* /api/card/detail API 를 활용하여 명함 수정 화면 데이터 조회
* 명함 추가 Flow 와 동일하게 필수 데이터는 항상 입력받도록 작업 (nickname, interestDomain etc..)
* 이미지의 경우, 새로운 이미지 업로드 시 profileImage 에 파일을 담아 보내면됨 (isImageRemoved = false)
  * 기존 이미지를 유지하는 경우, isImageRemoved 필드를 false,
  * 기존 이미지를 삭제하는 경우, isImageRemoved 필드를 true 로 보내면 됨
* 나머지 nullable 필드들은 Card Entity 에 Setter 추가하여 덮어씌우는 방식으로 구현



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 사용자들이 명함 정보를 업데이트하고 프로필 이미지를 교체하거나 삭제할 수 있는 기능이 추가되었습니다. 이 과정에서 필드 유효성 검증과 소유자 확인 절차가 강화되었습니다.
- **테스트**
  - 업데이트 시 전체 정보 변경, 이미지 유지/삭제, 필수 정보 누락 등 다양한 상황을 검증하는 통합 테스트가 추가되었습니다.
- **그 외 개선**
  - 파일 업로드 처리와 AWS S3 테스트 설정이 개선되어 안정성과 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->