### PR TITLE
[Feat] 최근 받은 명함 목록 조회

### DIFF
--- a/src/main/java/com/evenly/took/feature/card/api/CardApi.java
+++ b/src/main/java/com/evenly/took/feature/card/api/CardApi.java
@@ -12,6 +12,7 @@ import com.evenly.took.feature.card.dto.request.FixCardRequest;
 import com.evenly.took.feature.card.dto.request.FixFolderRequest;
 import com.evenly.took.feature.card.dto.request.FixReceivedCardRequest;
 import com.evenly.took.feature.card.dto.request.LinkRequest;
+import com.evenly.took.feature.card.dto.request.NewReceivedCardsRequest;
 import com.evenly.took.feature.card.dto.request.ReceiveCardRequest;
 import com.evenly.took.feature.card.dto.request.ReceivedCardsRequest;
 import com.evenly.took.feature.card.dto.request.RemoveFolderRequest;
@@ -214,6 +215,28 @@ public interface CardApi {
 	SuccessResponse<ReceivedCardListResponse> getReceivedCards(
 		User user,
 		@ParameterObject ReceivedCardsRequest request
+	);
+	
+	@Operation(
+		summary = "흥미로운 명함 목록 조회 (내 대표명함의 관심사와 하나라도 겹치는 명함)",
+		description = "새로 추가된 받은 명함 중, 내 대표명함의 관심사와 하나라도 겹치는 명함들을 조회합니다. 대표 명함이 없거나 관심사가 없는 경우 빈 목록을 반환합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "흥미로운 명함 목록 조회 성공")
+	})
+	SuccessResponse<ReceivedCardListResponse> getInterestingNewReceivedCards(
+		User user,
+		@ParameterObject NewReceivedCardsRequest request
+	);
+	
+	@Operation(
+		summary = "한줄 메모 명함 목록 조회 (관심사 불일치 + 메모 없음)",
+		description = "새로 추가된 받은 명함 중, 내 대표명함의 관심사와 겹치지 않고 메모가 없는 명함들을 조회합니다. 대표 명함이 없는 경우 모든 메모가 없는 명함을 반환합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "한줄 메모 명함 목록 조회 성공")
+	})
+	SuccessResponse<ReceivedCardListResponse> getMemoNeededNewReceivedCards(
+		User user,
+		@ParameterObject NewReceivedCardsRequest request
 	);
 
 	@Operation(

--- a/src/main/java/com/evenly/took/feature/card/api/CardController.java
+++ b/src/main/java/com/evenly/took/feature/card/api/CardController.java
@@ -25,6 +25,7 @@ import com.evenly.took.feature.card.dto.request.FixCardRequest;
 import com.evenly.took.feature.card.dto.request.FixFolderRequest;
 import com.evenly.took.feature.card.dto.request.FixReceivedCardRequest;
 import com.evenly.took.feature.card.dto.request.LinkRequest;
+import com.evenly.took.feature.card.dto.request.NewReceivedCardsRequest;
 import com.evenly.took.feature.card.dto.request.ReceiveCardRequest;
 import com.evenly.took.feature.card.dto.request.ReceivedCardsRequest;
 import com.evenly.took.feature.card.dto.request.RemoveFolderRequest;
@@ -174,6 +175,32 @@ public class CardController implements CardApi {
 		@ModelAttribute ReceivedCardsRequest request
 	) {
 		ReceivedCardListResponse response = cardService.findReceivedCards(user, request);
+		return SuccessResponse.of(response);
+	}
+	
+	/**
+	 * 흥미로운 명함 목록 조회 (내 대표명함의 관심사와 하나라도 겹치는 명함)
+	 * 새로 추가된 받은 명함 중, 내 대표명함의 관심사와 하나라도 겹치는 명함들을 반환합니다.
+	 */
+	@GetMapping("/api/card/receive/interesting")
+	public SuccessResponse<ReceivedCardListResponse> getInterestingNewReceivedCards(
+		@LoginUser User user,
+		@ModelAttribute NewReceivedCardsRequest request
+	) {
+		ReceivedCardListResponse response = cardService.findInterestingNewReceivedCards(user, request);
+		return SuccessResponse.of(response);
+	}
+	
+	/**
+	 * 한줄 메모 명함 목록 조회 (관심사 불일치 + 메모 없음)
+	 * 새로 추가된 받은 명함 중, 내 대표명함의 관심사와 겹치지 않고 메모가 없는 명함들을 반환합니다.
+	 */
+	@GetMapping("/api/card/receive/memo")
+	public SuccessResponse<ReceivedCardListResponse> getMemoNeededNewReceivedCards(
+		@LoginUser User user,
+		@ModelAttribute NewReceivedCardsRequest request
+	) {
+		ReceivedCardListResponse response = cardService.findMemoNeededNewReceivedCards(user, request);
 		return SuccessResponse.of(response);
 	}
 

--- a/src/main/java/com/evenly/took/feature/card/application/CardService.java
+++ b/src/main/java/com/evenly/took/feature/card/application/CardService.java
@@ -499,44 +499,24 @@ public class CardService {
 	}
 
 	/**
-	 * 새로 추가된 받은 명함 중, 내 대표명함의 관심사와 하나라도 겹치는 "흥미로운 명함" 목록을 조회합니다.
+	 * 새로 추가된 받은 명함 중, 내 대표명함과 관심사가 하나라도 겹치는 "흥미로운 명함" 목록을 조회합니다.
+	 * 관심사 기준: 관심도메인 겹침 or 소속정보 일치 or 세부직군 일치
 	 */
 	@Transactional(readOnly = true)
 	public ReceivedCardListResponse findInterestingNewReceivedCards(User user, NewReceivedCardsRequest request) {
 		LocalDateTime baseTime = request.baseTime() != null ? request.baseTime() : LocalDateTime.now();
 		LocalDateTime oneDayBefore = baseTime.minusDays(1);
 
-		List<String> userInterests = new ArrayList<>();
-		try {
-			Card primaryCard = cardRepository.findByUserIdAndIsPrimaryTrueAndDeletedAtIsNull(user.getId())
-				.orElse(null);
-
-			// 대표 명함이 있고, 관심 도메인이 있는 경우만 처리
-			if (primaryCard != null && primaryCard.getInterestDomain() != null) {
-				userInterests = primaryCard.getInterestDomain();
-			}
-		} catch (Exception e) {
-			log.warn("Failed to get primary card: {}", e.getMessage());
-		}
-
-		if (userInterests.isEmpty()) {
+		Card primaryCard = getPrimaryCard(user.getId());
+		if (primaryCard == null) {
 			return new ReceivedCardListResponse(new ArrayList<>());
 		}
 
 		List<ReceivedCard> newReceivedCards = receivedCardRepository.findNewReceivedCards(
 			user.getId(), baseTime, oneDayBefore);
 
-		List<String> finalUserInterests = userInterests;
 		List<ReceivedCard> interestingCards = newReceivedCards.stream()
-			.filter(rc -> {
-				List<String> cardInterests = rc.getCard().getInterestDomain();
-				if (cardInterests == null || cardInterests.isEmpty()) {
-					return false;
-				}
-
-				// 하나라도 겹치는지 확인
-				return cardInterests.stream().anyMatch(finalUserInterests::contains);
-			})
+			.filter(rc -> hasCommonInterest(primaryCard, rc.getCard()))
 			.collect(Collectors.toList());
 
 		interestingCards.forEach(rc -> updatePresignedImagePath(rc.getCard()));
@@ -545,30 +525,18 @@ public class CardService {
 	}
 
 	/**
-	 * 새로 추가된 받은 명함 중, 내 대표명함의 관심사와 겹치지 않고 메모가 없는 "한줄 메모가 필요한 명함" 목록을 조회합니다.
+	 * 새로 추가된 받은 명함 중, 내 대표명함과 관심사가 겹치지 않고 메모가 없는 "한줄 메모가 필요한 명함" 목록을 조회합니다.
+	 * 관심사 기준: 관심도메인 겹침 or 소속정보 일치 or 세부직군 일치
 	 */
 	@Transactional(readOnly = true)
 	public ReceivedCardListResponse findMemoNeededNewReceivedCards(User user, NewReceivedCardsRequest request) {
 		LocalDateTime baseTime = request.baseTime() != null ? request.baseTime() : LocalDateTime.now();
 		LocalDateTime oneDayBefore = baseTime.minusDays(1);
 
-		List<String> userInterests = new ArrayList<>();
-		try {
-			Card primaryCard = cardRepository.findByUserIdAndIsPrimaryTrueAndDeletedAtIsNull(user.getId())
-				.orElse(null);
-
-			// 대표 명함이 있고, 관심 도메인이 있는 경우만 처리
-			if (primaryCard != null && primaryCard.getInterestDomain() != null) {
-				userInterests = primaryCard.getInterestDomain();
-			}
-		} catch (Exception e) {
-			log.warn("Failed to get primary card: {}", e.getMessage());
-		}
+		Card primaryCard = getPrimaryCard(user.getId());
 
 		List<ReceivedCard> newReceivedCards = receivedCardRepository.findNewReceivedCards(
 			user.getId(), baseTime, oneDayBefore);
-
-		final List<String> finalUserInterests = userInterests;
 
 		List<ReceivedCard> memoNeededCards = newReceivedCards.stream()
 			.filter(rc -> {
@@ -577,27 +545,101 @@ public class CardService {
 					return false;
 				}
 
-				// 대표 명함이 없거나 관심사가 없는 경우, 메모가 없는 모든 명함 포함
-				if (finalUserInterests.isEmpty()) {
+				// 대표 명함이 없는 경우, 메모가 없는 모든 명함 포함
+				if (primaryCard == null) {
 					return true;
 				}
 
-				// 카드의 관심 도메인 확인
-				List<String> cardInterests = rc.getCard().getInterestDomain();
-
-				// 카드에 관심 도메인이 없는 경우 포함
-				if (cardInterests == null || cardInterests.isEmpty()) {
-					return true;
-				}
-
-				// 겹치는 관심사가 없는 경우에만 포함
-				return cardInterests.stream().noneMatch(finalUserInterests::contains);
+				// 공통 관심사가 없는 경우에만 포함
+				return !hasCommonInterest(primaryCard, rc.getCard());
 			})
 			.collect(Collectors.toList());
 
 		memoNeededCards.forEach(rc -> updatePresignedImagePath(rc.getCard()));
 
 		return cardMapper.toReceivedCardListResponse(memoNeededCards);
+	}
+
+	/**
+	 * 사용자의 대표 명함을 조회합니다.
+	 */
+	private Card getPrimaryCard(Long userId) {
+		try {
+			return cardRepository.findByUserIdAndIsPrimaryTrueAndDeletedAtIsNull(userId)
+				.orElse(null);
+		} catch (Exception e) {
+			log.warn("Failed to get primary card: {}", e.getMessage());
+			return null;
+		}
+	}
+
+	/**
+	 * 두 명함 간에 공통 관심사가 있는지 확인합니다.
+	 * 관심사 기준: 관심도메인 겹침 or 소속정보 일치 or 세부직군 일치
+	 */
+	private boolean hasCommonInterest(Card primaryCard, Card otherCard) {
+		if (hasCommonInterestDomain(primaryCard, otherCard)) {
+			return true;
+		}
+
+		if (hasSameOrganization(primaryCard, otherCard)) {
+			return true;
+		}
+
+		if (hasSameCareer(primaryCard, otherCard)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * 두 명함 간에 공통 관심 도메인이 있는지 확인합니다.
+	 */
+	private boolean hasCommonInterestDomain(Card primaryCard, Card otherCard) {
+		List<String> primaryInterests = primaryCard.getInterestDomain();
+		List<String> otherInterests = otherCard.getInterestDomain();
+
+		if (primaryInterests == null || primaryInterests.isEmpty() ||
+			otherInterests == null || otherInterests.isEmpty()) {
+			return false;
+		}
+
+		return otherInterests.stream().anyMatch(primaryInterests::contains);
+	}
+
+	/**
+	 * 두 명함의 소속정보가 일치하는지 확인합니다.
+	 */
+	private boolean hasSameOrganization(Card primaryCard, Card otherCard) {
+		String primaryOrg = primaryCard.getOrganization();
+		String otherOrg = otherCard.getOrganization();
+
+		if (primaryOrg == null || primaryOrg.trim().isEmpty() ||
+			otherOrg == null || otherOrg.trim().isEmpty()) {
+			return false;
+		}
+
+		return primaryOrg.trim().equalsIgnoreCase(otherOrg.trim());
+	}
+
+	/**
+	 * 두 명함의 세부직군이 일치하는지 확인합니다.
+	 */
+	private boolean hasSameCareer(Card primaryCard, Card otherCard) {
+		Career primaryCareer = primaryCard.getCareer();
+		Career otherCareer = otherCard.getCareer();
+
+		if (primaryCareer == null || otherCareer == null) {
+			return false;
+		}
+
+		// 직업 카테고리(Job) 일치 여부 확인
+		if (Objects.equals(primaryCareer.getId(), otherCareer.getId())) {
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/src/main/java/com/evenly/took/feature/card/dao/CardRepository.java
+++ b/src/main/java/com/evenly/took/feature/card/dao/CardRepository.java
@@ -34,4 +34,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
 	@Modifying(clearAutomatically = true)
 	@Query("UPDATE Card c SET c.deletedAt = :now WHERE c.user.id = :userId AND c.deletedAt IS NULL")
 	int softDeleteAllByUserId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
+	
+	/**
+	 * 사용자의 대표 명함을 조회합니다.
+	 */
+	Optional<Card> findByUserIdAndIsPrimaryTrueAndDeletedAtIsNull(Long userId);
 }

--- a/src/main/java/com/evenly/took/feature/card/dao/ReceivedCardRepository.java
+++ b/src/main/java/com/evenly/took/feature/card/dao/ReceivedCardRepository.java
@@ -22,4 +22,16 @@ public interface ReceivedCardRepository extends JpaRepository<ReceivedCard, Long
 	@Modifying(clearAutomatically = true)
 	@Query("UPDATE ReceivedCard rc SET rc.deletedAt = :now WHERE rc.user.id = :userId AND rc.deletedAt IS NULL")
 	int softDeleteAllByUserId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
+	
+	/**
+	 * 특정 사용자의 baseTime 이전 하루 동안 새로 추가된 받은 명함 목록을 조회합니다.
+	 */
+	@Query("SELECT rc FROM ReceivedCard rc WHERE rc.user.id = :userId AND rc.deletedAt IS NULL " +
+	       "AND rc.createdAt < :baseTime AND rc.createdAt >= :oneDayBefore " +
+	       "ORDER BY rc.id DESC")
+	List<ReceivedCard> findNewReceivedCards(
+		@Param("userId") Long userId, 
+		@Param("baseTime") LocalDateTime baseTime, 
+		@Param("oneDayBefore") LocalDateTime oneDayBefore
+	);
 }

--- a/src/main/java/com/evenly/took/feature/card/dto/request/NewReceivedCardsRequest.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/request/NewReceivedCardsRequest.java
@@ -1,0 +1,12 @@
+package com.evenly.took.feature.card.dto.request;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "새로 추가된 받은 명함 조회 요청")
+public record NewReceivedCardsRequest(
+	@Schema(description = "기준 시간 (이 시간 이전에 추가된 명함들을 조회) => 입력하지 않는 경우 현재 시점 기준으로 조회", example = "2023-01-01T00:00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	LocalDateTime baseTime
+) {
+}

--- a/src/main/java/com/evenly/took/feature/card/exception/CardErrorCode.java
+++ b/src/main/java/com/evenly/took/feature/card/exception/CardErrorCode.java
@@ -21,6 +21,7 @@ public enum CardErrorCode implements ErrorCode {
 	RECEIVED_CARD_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 수신 명함입니다."),
 	INVALID_CRAWL_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 크롤링 링크입니다."),
 	INVALID_CARD_OWNER(HttpStatus.BAD_REQUEST, "자신이 소유한 카드만 수정할 수 있습니다."),
+	PRIMARY_CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "대표 명함을 찾을 수 없습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/test/java/com/evenly/took/feature/card/api/CardIntegrationTest.java
+++ b/src/test/java/com/evenly/took/feature/card/api/CardIntegrationTest.java
@@ -1095,12 +1095,16 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 	class 흥미로운_받은_명함_목록_조회 {
 
 		@Test
-		void 관심사가_일치하는_흥미로운_명함_조회_성공() {
+		void 흥미로운_명함_조회_성공() {
+			Career career = careerFixture.serverDeveloper();
+			Career differentCareer = careerFixture.productDesigner();
 			// given
 			Card primaryCard = cardFixture.creator()
 				.user(mockUser)
+				.career(career)
 				.nickname("내 대표명함")
 				.interestDomain(List.of("웹", "백엔드"))
+				.organization("ABC회사")
 				.isPrimary(true)
 				.create();
 
@@ -1109,8 +1113,10 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 				.create();
 			Card interestingCard = cardFixture.creator()
 				.user(cardOwner1)
+				.career(career)
 				.nickname("흥미로운 명함")
 				.interestDomain(List.of("웹", "프론트엔드"))  // 관심사 "웹"이 겹침
+				.organization("XYZ회사")
 				.create();
 
 			User cardOwner2 = userFixture.creator()
@@ -1118,8 +1124,10 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 				.create();
 			Card nonInterestingCard = cardFixture.creator()
 				.user(cardOwner2)
+				.career(differentCareer)
 				.nickname("관심없는 명함")
 				.interestDomain(List.of("클라우드", "AI"))  // 관심사가 겹치지 않음
+				.organization("DEF회사")
 				.create();
 
 			receivedCardFixture.creator()
@@ -1154,27 +1162,127 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 		}
 
 		@Test
-		void 관심사가_없는_경우_빈_결과_반환() {
+		void 동일_소속사_명함은_관심도메인_불일치해도_흥미로운_명함_조회_성공() {
 			// given
 			Card primaryCard = cardFixture.creator()
 				.user(mockUser)
 				.nickname("내 대표명함")
-				.interestDomain(List.of())
+				.interestDomain(List.of("웹", "백엔드"))
+				.organization("ABC회사")
 				.isPrimary(true)
 				.create();
 
 			User cardOwner = userFixture.creator()
 				.name("명함소유자")
 				.create();
-			Card otherCard = cardFixture.creator()
+			Card sameOrgCard = cardFixture.creator()
 				.user(cardOwner)
-				.nickname("다른 명함")
-				.interestDomain(List.of("웹", "백엔드"))
+				.nickname("동일회사 명함")
+				.interestDomain(List.of("클라우드", "AI"))  // 관심도메인 불일치
+				.organization("ABC회사")  // 소속정보 일치
 				.create();
 
 			receivedCardFixture.creator()
 				.user(mockUser)
-				.card(otherCard)
+				.card(sameOrgCard)
+				.create();
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/receive/interesting")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).hasSize(1);
+			assertThat(cards.get(0).get("nickname")).isEqualTo(sameOrgCard.getNickname());
+		}
+
+		@Test
+		void 동일_직군_명함은_관심도메인_불일치해도_흥미로운_명함_조회_성공() {
+			// given
+			Career myCareer = careerFixture.serverDeveloper();
+			Card primaryCard = cardFixture.creator()
+				.user(mockUser)
+				.nickname("내 대표명함")
+				.career(myCareer)
+				.interestDomain(List.of("웹", "백엔드"))
+				.organization("ABC회사")
+				.isPrimary(true)
+				.create();
+
+			User cardOwner = userFixture.creator()
+				.name("명함소유자")
+				.create();
+			Card sameJobCard = cardFixture.creator()
+				.user(cardOwner)
+				.nickname("같은직군 명함")
+				.career(myCareer)  // 같은 직군
+				.interestDomain(List.of("클라우드", "AI"))  // 관심도메인 불일치
+				.organization("XYZ회사")  // 소속정보 불일치
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(sameJobCard)
+				.create();
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/receive/interesting")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).hasSize(1);
+			assertThat(cards.get(0).get("nickname")).isEqualTo(sameJobCard.getNickname());
+		}
+
+		@Test
+		void 세_조건_모두_불일치하는_명함은_흥미로운_명함에서_제외() {
+			// given
+			Career myCareer = careerFixture.serverDeveloper();
+			Career otherCareer = careerFixture.productDesigner();
+
+			Card primaryCard = cardFixture.creator()
+				.user(mockUser)
+				.nickname("내 대표명함")
+				.career(myCareer)
+				.interestDomain(List.of("웹", "백엔드"))
+				.organization("ABC회사")
+				.isPrimary(true)
+				.create();
+
+			User cardOwner = userFixture.creator()
+				.name("명함소유자")
+				.create();
+			Card nonMatchingCard = cardFixture.creator()
+				.user(cardOwner)
+				.nickname("불일치 명함")
+				.career(otherCareer)  // 다른 직군
+				.interestDomain(List.of("클라우드", "AI"))  // 관심도메인 불일치
+				.organization("XYZ회사")  // 소속정보 불일치
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(nonMatchingCard)
 				.create();
 
 			// when
@@ -1237,10 +1345,15 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 		@Test
 		void 관심사가_겹치지_않고_메모가_없는_명함_조회_성공() {
 			// given
+			Career myCareer = careerFixture.serverDeveloper();
+			Career otherCareer = careerFixture.productDesigner();
+
 			Card primaryCard = cardFixture.creator()
 				.user(mockUser)
 				.nickname("내 대표명함")
+				.career(myCareer)
 				.interestDomain(List.of("웹", "백엔드"))
+				.organization("ABC회사")
 				.isPrimary(true)
 				.create();
 
@@ -1250,7 +1363,9 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 			Card memoNeededCard = cardFixture.creator()
 				.user(cardOwner1)
 				.nickname("메모 필요한 명함")
+				.career(otherCareer)  // 다른 직군
 				.interestDomain(List.of("클라우드", "AI"))  // 관심사가 겹치지 않음
+				.organization("XYZ회사")  // 다른 회사
 				.create();
 
 			User cardOwner2 = userFixture.creator()
@@ -1259,7 +1374,9 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 			Card interestingCard = cardFixture.creator()
 				.user(cardOwner2)
 				.nickname("관심사 일치 명함")
-				.interestDomain(List.of("웹", "프론트엔드"))
+				.career(myCareer)  // 같은 직군
+				.interestDomain(List.of("웹", "프론트엔드"))  // 관심도메인 일치
+				.organization("DEF회사")  // 다른 회사
 				.create();
 
 			User cardOwner3 = userFixture.creator()
@@ -1268,7 +1385,9 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 			Card cardWithMemo = cardFixture.creator()
 				.user(cardOwner3)
 				.nickname("메모 있는 명함")
-				.interestDomain(List.of("데이터", "ML"))
+				.career(otherCareer)  // 다른 직군
+				.interestDomain(List.of("데이터", "ML"))  // 관심사 불일치
+				.organization("GHI회사")  // 다른 회사
 				.create();
 
 			receivedCardFixture.creator()
@@ -1306,6 +1425,139 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 
 			assertThat(cards).hasSize(1);
 			assertThat(cards.get(0).get("nickname")).isEqualTo(memoNeededCard.getNickname());
+		}
+
+		@Test
+		void 메모_있는_명함은_관심사_불일치해도_제외() {
+			// given
+			Card primaryCard = cardFixture.creator()
+				.user(mockUser)
+				.nickname("내 대표명함")
+				.interestDomain(List.of("웹", "백엔드"))
+				.isPrimary(true)
+				.create();
+
+			User cardOwner = userFixture.creator()
+				.name("명함소유자")
+				.create();
+			Card nonMatchingWithMemo = cardFixture.creator()
+				.user(cardOwner)
+				.nickname("관심사 불일치 메모있는 명함")
+				.interestDomain(List.of("클라우드", "AI"))  // 관심사 불일치
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(nonMatchingWithMemo)
+				.memo("메모 있음") // 메모 있음
+				.create();
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/receive/memo")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).isEmpty();
+		}
+
+		@Test
+		void 같은_직군명함은_메모가_없어도_메모필요에서_제외() {
+			// given
+			Career myCareer = careerFixture.serverDeveloper();
+
+			Card primaryCard = cardFixture.creator()
+				.user(mockUser)
+				.nickname("내 대표명함")
+				.career(myCareer)
+				.interestDomain(List.of("웹", "백엔드"))
+				.isPrimary(true)
+				.create();
+
+			User cardOwner = userFixture.creator()
+				.name("명함소유자")
+				.create();
+			Card sameJobCard = cardFixture.creator()
+				.user(cardOwner)
+				.nickname("같은직군 명함")
+				.career(myCareer)  // 같은 직군
+				.interestDomain(List.of("클라우드", "AI"))  // 관심사 불일치
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(sameJobCard)
+				.create();  // 메모 없음
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/receive/memo")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).isEmpty();
+		}
+
+		@Test
+		void 같은_소속사_명함은_메모가_없어도_메모필요에서_제외() {
+			// given
+			Card primaryCard = cardFixture.creator()
+				.user(mockUser)
+				.nickname("내 대표명함")
+				.interestDomain(List.of("웹", "백엔드"))
+				.organization("ABC회사")
+				.isPrimary(true)
+				.create();
+
+			User cardOwner = userFixture.creator()
+				.name("명함소유자")
+				.create();
+			Card sameOrgCard = cardFixture.creator()
+				.user(cardOwner)
+				.nickname("동일회사 명함")
+				.interestDomain(List.of("클라우드", "AI"))  // 관심사 불일치
+				.organization("ABC회사")  // 소속정보 일치
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(sameOrgCard)
+				.create();  // 메모 없음
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/receive/memo")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).isEmpty();
 		}
 
 		@Test

--- a/src/test/java/com/evenly/took/feature/card/api/CardIntegrationTest.java
+++ b/src/test/java/com/evenly/took/feature/card/api/CardIntegrationTest.java
@@ -1,11 +1,10 @@
 package com.evenly.took.feature.card.api;
 
-import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static io.restassured.RestAssured.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.List;
@@ -1089,6 +1088,318 @@ public class CardIntegrationTest extends JwtMockIntegrationTest {
 
 			assertThat(cards).hasSize(1);
 			assertThat(cards.get(0).get("nickname")).isEqualTo(card.getNickname());
+		}
+	}
+
+	@Nested
+	class 흥미로운_받은_명함_목록_조회 {
+
+		@Test
+		void 관심사가_일치하는_흥미로운_명함_조회_성공() {
+			// given
+			Card primaryCard = cardFixture.creator()
+				.user(mockUser)
+				.nickname("내 대표명함")
+				.interestDomain(List.of("웹", "백엔드"))
+				.isPrimary(true)
+				.create();
+
+			User cardOwner1 = userFixture.creator()
+				.name("명함소유자1")
+				.create();
+			Card interestingCard = cardFixture.creator()
+				.user(cardOwner1)
+				.nickname("흥미로운 명함")
+				.interestDomain(List.of("웹", "프론트엔드"))  // 관심사 "웹"이 겹침
+				.create();
+
+			User cardOwner2 = userFixture.creator()
+				.name("명함소유자2")
+				.create();
+			Card nonInterestingCard = cardFixture.creator()
+				.user(cardOwner2)
+				.nickname("관심없는 명함")
+				.interestDomain(List.of("클라우드", "AI"))  // 관심사가 겹치지 않음
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(interestingCard)
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(nonInterestingCard)
+				.create();
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/receive/interesting")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			assertThat(responseMap.get("status")).isEqualTo("OK");
+
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).hasSize(1);
+			assertThat(cards.get(0).get("nickname")).isEqualTo(interestingCard.getNickname());
+		}
+
+		@Test
+		void 관심사가_없는_경우_빈_결과_반환() {
+			// given
+			Card primaryCard = cardFixture.creator()
+				.user(mockUser)
+				.nickname("내 대표명함")
+				.interestDomain(List.of())
+				.isPrimary(true)
+				.create();
+
+			User cardOwner = userFixture.creator()
+				.name("명함소유자")
+				.create();
+			Card otherCard = cardFixture.creator()
+				.user(cardOwner)
+				.nickname("다른 명함")
+				.interestDomain(List.of("웹", "백엔드"))
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(otherCard)
+				.create();
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/receive/interesting")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).isEmpty();
+		}
+
+		@Test
+		void 대표_명함이_없는_경우_빈_목록_반환() {
+			// given
+			User cardOwner = userFixture.creator()
+				.name("명함소유자")
+				.create();
+			Card otherCard = cardFixture.creator()
+				.user(cardOwner)
+				.nickname("다른 명함")
+				.interestDomain(List.of("웹", "백엔드"))
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(otherCard)
+				.create();
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/receive/interesting")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).isEmpty();
+		}
+	}
+
+	@Nested
+	class 메모가_필요한_받은_명함_목록_조회 {
+
+		@Test
+		void 관심사가_겹치지_않고_메모가_없는_명함_조회_성공() {
+			// given
+			Card primaryCard = cardFixture.creator()
+				.user(mockUser)
+				.nickname("내 대표명함")
+				.interestDomain(List.of("웹", "백엔드"))
+				.isPrimary(true)
+				.create();
+
+			User cardOwner1 = userFixture.creator()
+				.name("명함소유자1")
+				.create();
+			Card memoNeededCard = cardFixture.creator()
+				.user(cardOwner1)
+				.nickname("메모 필요한 명함")
+				.interestDomain(List.of("클라우드", "AI"))  // 관심사가 겹치지 않음
+				.create();
+
+			User cardOwner2 = userFixture.creator()
+				.name("명함소유자2")
+				.create();
+			Card interestingCard = cardFixture.creator()
+				.user(cardOwner2)
+				.nickname("관심사 일치 명함")
+				.interestDomain(List.of("웹", "프론트엔드"))
+				.create();
+
+			User cardOwner3 = userFixture.creator()
+				.name("명함소유자3")
+				.create();
+			Card cardWithMemo = cardFixture.creator()
+				.user(cardOwner3)
+				.nickname("메모 있는 명함")
+				.interestDomain(List.of("데이터", "ML"))
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(memoNeededCard)
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(interestingCard)
+				.create();
+
+			ReceivedCard receivedWithMemo = receivedCardFixture.creator()
+				.user(mockUser)
+				.card(cardWithMemo)
+				.memo("이 사람은 데이터 분석가입니다.")
+				.create();
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/receive/memo")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			assertThat(responseMap.get("status")).isEqualTo("OK");
+
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).hasSize(1);
+			assertThat(cards.get(0).get("nickname")).isEqualTo(memoNeededCard.getNickname());
+		}
+
+		@Test
+		void 대표_명함이_없는_경우에도_메모가_없는_명함_조회_가능() {
+			// given
+			User cardOwner = userFixture.creator()
+				.name("명함소유자")
+				.create();
+			Card otherCard = cardFixture.creator()
+				.user(cardOwner)
+				.nickname("메모 필요한 명함")
+				.interestDomain(List.of("웹", "백엔드"))
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(otherCard)
+				.create();
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/receive/memo")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).hasSize(1);
+			assertThat(cards.get(0).get("nickname")).isEqualTo(otherCard.getNickname());
+		}
+
+		@Test
+		void 모든_명함에_메모가_있는_경우_빈_결과_반환() {
+			// given
+			Card primaryCard = cardFixture.creator()
+				.user(mockUser)
+				.nickname("내 대표명함")
+				.interestDomain(List.of("웹", "백엔드"))
+				.isPrimary(true)
+				.create();
+
+			User cardOwner1 = userFixture.creator()
+				.name("명함소유자1")
+				.create();
+			Card card1 = cardFixture.creator()
+				.user(cardOwner1)
+				.nickname("메모있는 명함1")
+				.interestDomain(List.of("클라우드", "AI"))  // 관심사가 겹치지 않음
+				.create();
+
+			User cardOwner2 = userFixture.creator()
+				.name("명함소유자2")
+				.create();
+			Card card2 = cardFixture.creator()
+				.user(cardOwner2)
+				.nickname("메모있는 명함2")
+				.interestDomain(List.of("데이터", "ML"))  // 관심사가 겹치지 않음
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(card1)
+				.memo("첫번째 명함 메모")
+				.create();
+
+			receivedCardFixture.creator()
+				.user(mockUser)
+				.card(card2)
+				.memo("두번째 명함 메모")
+				.create();
+
+			// when
+			ExtractableResponse<Response> response = given()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.header("Authorization", authToken)
+				.when()
+				.get("/api/card/receive/memo")
+				.then()
+				.statusCode(HttpStatus.OK.value())
+				.extract();
+
+			// then
+			Map<String, Object> responseMap = response.as(Map.class);
+			Map<String, Object> dataMap = (Map<String, Object>)responseMap.get("data");
+			List<Map<String, Object>> cards = (List<Map<String, Object>>)dataMap.get("cards");
+
+			assertThat(cards).isEmpty();
 		}
 	}
 

--- a/src/test/java/com/evenly/took/global/domain/CardFixture.java
+++ b/src/test/java/com/evenly/took/global/domain/CardFixture.java
@@ -30,7 +30,7 @@ public class CardFixture extends CardBase {
 		}
 		Card card = Card.builder()
 			.user(user)
-			.career(careerFixture.serverDeveloper())
+			.career(career)
 			.previewInfo(previewInfo)
 			.nickname(nickname)
 			.imagePath(imagePath)


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
- #116 

## 📌 개발 이유
- 푸시알림을 클릭하였을때 조회되는 최근 받은 명함 목록 조회 
  - 흥미로운 받은명함 목록 조회
  - 한줄메모 명함 목록 조회

## 💻 수정 사항
- 흥미로운 받은명함
  - 입력 시간 or 조회 시점 기준 24 시간 전 내에 받은 명함
  - 내 대표명함의 관심 도메인과 하나라도 겹치는 관심사 + 세부직군 + 조직 일치 여부 존재 
  - 대표명함이 없는 경우 빈 배열 반환
- 한줄 메모 받은명함
  - 입력 시간 or 조회 시점 기준 24 시간 전 내에 받은 명함
  - 내 대표명함과 흥미로운 명함 조건이 겹치는 내용이 없음
  - 대표명함이 없는 경우 시간 내에 수령한 모든 받은 명함 반환



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 사용자의 관심사와 연관된 새로운 명함 목록을 조회할 수 있는 기능이 추가되었습니다.
	- 메모가 없는 명함을 별도로 확인할 수 있는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->