### PR TITLE
[Feat] 한 줄 메모 여러개의 명함에 동시에 업데이트 API

### DIFF
--- a/src/main/java/com/evenly/took/feature/card/api/CardApi.java
+++ b/src/main/java/com/evenly/took/feature/card/api/CardApi.java
@@ -18,6 +18,7 @@ import com.evenly.took.feature.card.dto.request.ReceivedCardsRequest;
 import com.evenly.took.feature.card.dto.request.RemoveFolderRequest;
 import com.evenly.took.feature.card.dto.request.RemoveReceivedCardsRequest;
 import com.evenly.took.feature.card.dto.request.SetReceivedCardsFolderRequest;
+import com.evenly.took.feature.card.dto.request.SetReceivedCardsMemoRequest;
 import com.evenly.took.feature.card.dto.response.CardDetailResponse;
 import com.evenly.took.feature.card.dto.response.CardResponse;
 import com.evenly.took.feature.card.dto.response.CareersResponse;
@@ -267,6 +268,21 @@ public interface CardApi {
 	SuccessResponse<Void> fixReceivedCard(
 		User user,
 		FixReceivedCardRequest request
+	);
+	
+	@Operation(
+		summary = "여러 개의 받은 명함에 한줄 메모 추가",
+		description = "여러 개의 수신한 명함에 한 번에 한줄 메모를 추가합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "한줄 메모 추가 성공"),
+		@ApiResponse(responseCode = "404", description = "받은 명함을 찾을 수 없음",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "403", description = "권한이 없음",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	SuccessResponse<Void> setReceivedCardsMemo(
+		User user,
+		SetReceivedCardsMemoRequest request
 	);
 
 	@Operation(

--- a/src/main/java/com/evenly/took/feature/card/api/CardController.java
+++ b/src/main/java/com/evenly/took/feature/card/api/CardController.java
@@ -31,6 +31,7 @@ import com.evenly.took.feature.card.dto.request.ReceivedCardsRequest;
 import com.evenly.took.feature.card.dto.request.RemoveFolderRequest;
 import com.evenly.took.feature.card.dto.request.RemoveReceivedCardsRequest;
 import com.evenly.took.feature.card.dto.request.SetReceivedCardsFolderRequest;
+import com.evenly.took.feature.card.dto.request.SetReceivedCardsMemoRequest;
 import com.evenly.took.feature.card.dto.response.CardDetailResponse;
 import com.evenly.took.feature.card.dto.response.CardResponse;
 import com.evenly.took.feature.card.dto.response.CareersResponse;
@@ -220,6 +221,15 @@ public class CardController implements CardApi {
 	) {
 		cardService.updateReceivedCard(user, request);
 		return SuccessResponse.ok("명함 업데이트 성공");
+	}
+	
+	@PutMapping("/api/card/receive/memo/batch")
+	public SuccessResponse<Void> setReceivedCardsMemo(
+		@LoginUser User user,
+		@RequestBody @Valid SetReceivedCardsMemoRequest request
+	) {
+		cardService.updateReceivedCardsMemo(user, request.cardMemos());
+		return SuccessResponse.ok("한줄 메모 추가 성공");
 	}
 
 	@PutMapping(value = "/api/card", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/evenly/took/feature/card/application/CardService.java
+++ b/src/main/java/com/evenly/took/feature/card/application/CardService.java
@@ -37,6 +37,7 @@ import com.evenly.took.feature.card.dto.request.ReceivedCardsRequest;
 import com.evenly.took.feature.card.dto.request.RemoveFolderRequest;
 import com.evenly.took.feature.card.dto.request.RemoveReceivedCardsRequest;
 import com.evenly.took.feature.card.dto.request.SetReceivedCardsFolderRequest;
+import com.evenly.took.feature.card.dto.request.SetReceivedCardsMemoRequest;
 import com.evenly.took.feature.card.dto.response.CardDetailResponse;
 import com.evenly.took.feature.card.dto.response.CardResponse;
 import com.evenly.took.feature.card.dto.response.CareersResponse;
@@ -322,6 +323,14 @@ public class CardService {
 	public void updateReceivedCard(User user, FixReceivedCardRequest request) {
 		ReceivedCard receivedCard = findReceivedCardByUserAndCardId(user.getId(), request.cardId());
 		receivedCard.updateMemo(request.memo());
+	}
+	
+	@Transactional
+	public void updateReceivedCardsMemo(User user, List<SetReceivedCardsMemoRequest.CardMemo> cardMemos) {
+		for (SetReceivedCardsMemoRequest.CardMemo cardMemo : cardMemos) {
+			ReceivedCard receivedCard = findReceivedCardByUserAndCardId(user.getId(), cardMemo.cardId());
+			receivedCard.updateMemo(cardMemo.memo());
+		}
 	}
 
 	@Transactional

--- a/src/main/java/com/evenly/took/feature/card/dto/request/SetReceivedCardsMemoRequest.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/request/SetReceivedCardsMemoRequest.java
@@ -1,0 +1,28 @@
+package com.evenly.took.feature.card.dto.request;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "여러 개의 받은 명함에 한줄 메모를 추가하기 위한 요청", requiredMode = Schema.RequiredMode.REQUIRED)
+public record SetReceivedCardsMemoRequest(
+    @NotEmpty
+    @Schema(description = "메모를 추가할 명함 정보 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Size(min = 1, message = "최소 하나 이상의 명함 정보가 필요합니다")
+    List<@Valid CardMemo> cardMemos
+) {
+    @Schema(description = "명함과 메모 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+    public record CardMemo(
+        @NotNull
+        @Schema(description = "명함 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long cardId,
+
+        @Schema(description = "메모 내용", example = "디프만에서 만난 개발자")
+        String memo
+    ) {
+    }
+}


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
- #118 

## 📌 개발 이유
- 푸시알림을 통해서 조회된 최근에 받은 명함 목록에, 한 줄 메모 여러개를 동시에 추가하는 API 를 구현하였습니다

## 💻 수정 사항
- [PUT] /api/card/receive/memo/batch  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 여러 개의 받은 명함에 한 번에 한줄 메모를 추가할 수 있는 기능이 추가되었습니다.

- **버그 수정**
	- 존재하지 않거나 다른 사용자의 받은 명함에 메모 추가 시 올바른 오류 응답이 제공됩니다.
	- 빈 메모 리스트, 인증되지 않은 요청 등 다양한 예외 상황에 대한 처리가 개선되었습니다.

- **테스트**
	- 받은 명함에 한줄 메모를 일괄 추가하는 기능에 대한 통합 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->