### PR TITLE
[Fix] User AllowPush  초기화 문제 해결

### DIFF
--- a/src/main/java/com/evenly/took/feature/auth/client/apple/AppleUserClient.java
+++ b/src/main/java/com/evenly/took/feature/auth/client/apple/AppleUserClient.java
@@ -9,6 +9,7 @@ import com.evenly.took.feature.auth.client.apple.dto.response.AppleUserResponse;
 import com.evenly.took.feature.auth.domain.OAuthIdentifier;
 import com.evenly.took.feature.auth.domain.OAuthType;
 import com.evenly.took.feature.auth.exception.AuthErrorCode;
+import com.evenly.took.feature.user.domain.AllowPush;
 import com.evenly.took.feature.user.domain.User;
 import com.evenly.took.global.exception.TookException;
 
@@ -61,10 +62,16 @@ public class AppleUserClient implements UserClient {
 			.oauthType(supportType())
 			.build();
 
+		AllowPush allowPush = AllowPush.builder()
+			.allowPushContent(null)
+			.allowPushNotification(false)
+			.build();
+
 		return User.builder()
 			.name(response.name() != null ? response.name() : response.email())
 			.email(response.email())
 			.oauthIdentifier(oAuthIdentifier)
+			.allowPush(allowPush)
 			.build();
 	}
 }

--- a/src/main/java/com/evenly/took/feature/auth/client/google/GoogleUserClient.java
+++ b/src/main/java/com/evenly/took/feature/auth/client/google/GoogleUserClient.java
@@ -10,6 +10,7 @@ import com.evenly.took.feature.auth.client.google.dto.response.GoogleUserInfoRes
 import com.evenly.took.feature.auth.domain.OAuthIdentifier;
 import com.evenly.took.feature.auth.domain.OAuthType;
 import com.evenly.took.feature.auth.exception.AuthErrorCode;
+import com.evenly.took.feature.user.domain.AllowPush;
 import com.evenly.took.feature.user.domain.User;
 import com.evenly.took.global.exception.TookException;
 
@@ -45,10 +46,16 @@ public class GoogleUserClient implements UserClient {
 			.oauthType(OAuthType.GOOGLE)
 			.build();
 
+		AllowPush allowPush = AllowPush.builder()
+			.allowPushContent(null)
+			.allowPushNotification(false)
+			.build();
+
 		return User.builder()
 			.oauthIdentifier(oauthIdentifier)
 			.name(userInfoResponse.name())
 			.email(userInfoResponse.email())
+			.allowPush(allowPush)
 			.build();
 	}
 }

--- a/src/main/java/com/evenly/took/feature/auth/client/kakao/KakaoUserClient.java
+++ b/src/main/java/com/evenly/took/feature/auth/client/kakao/KakaoUserClient.java
@@ -8,6 +8,7 @@ import com.evenly.took.feature.auth.client.kakao.dto.response.KakaoTokenResponse
 import com.evenly.took.feature.auth.client.kakao.dto.response.KakaoUserResponse;
 import com.evenly.took.feature.auth.domain.OAuthIdentifier;
 import com.evenly.took.feature.auth.domain.OAuthType;
+import com.evenly.took.feature.user.domain.AllowPush;
 import com.evenly.took.feature.user.domain.User;
 
 import lombok.RequiredArgsConstructor;
@@ -36,10 +37,17 @@ public class KakaoUserClient implements UserClient {
 			.oauthId(response.id().toString())
 			.oauthType(supportType())
 			.build();
+
+		AllowPush allowPush = AllowPush.builder()
+			.allowPushContent(null)
+			.allowPushNotification(false)
+			.build();
+
 		return User.builder()
 			.name(response.kakaoAccount().nickname())
 			.email(response.kakaoAccount().email())
 			.oauthIdentifier(oAuthIdentifier)
+			.allowPush(allowPush)
 			.build();
 	}
 }


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
* #124 

## 📌 개발 이유
- User AllowPush  초기화 문제 해결

## 💻 수정 사항
- User signUp 시에 각 OAuth에서 User builder에 allowPush도 초기화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - Apple, Google, Kakao 소셜 로그인 시 사용자 정보에 알림 설정이 기본값(푸시 콘텐츠 없음, 푸시 알림 비활성화)으로 초기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->