### PR TITLE
[Fix] slack alert condition update

### DIFF
--- a/src/main/java/com/evenly/took/global/monitoring/slack/SlackErrorAlertAspect.java
+++ b/src/main/java/com/evenly/took/global/monitoring/slack/SlackErrorAlertAspect.java
@@ -8,7 +8,12 @@ import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import com.evenly.took.global.exception.TookException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,11 +31,16 @@ public class SlackErrorAlertAspect {
 		throwing = "ex"
 	)
 	public void sendErrorAlert(JoinPoint joinPoint, Throwable ex) {
+
+		if (!isInternalServerError(ex)) {
+			return;
+		}
+
 		String controllerClass = joinPoint.getSignature().getDeclaringType().getSimpleName();
 		String controllerMethod = joinPoint.getSignature().getName();
 
 		StackTraceElement origin = Arrays.stream(ex.getStackTrace())
-			.filter(it -> it.getClassName().startsWith("com.evenly")) // 패키지명 기준 필터링
+			.filter(it -> it.getClassName().startsWith("com.evenly"))
 			.findFirst()
 			.orElse(ex.getStackTrace()[0]);
 		String errorLocation = origin.toString();
@@ -47,6 +57,23 @@ public class SlackErrorAlertAspect {
 		errorDetails.put("========================[ 추가 Exception 정보 ]========================", "");
 		errorDetails.put("요약", ex.getClass().getSimpleName());
 		errorDetails.put("전체", ex.getClass().getName());
+
 		slackService.sendMessage(title, errorDetails);
 	}
+
+	private boolean isInternalServerError(Throwable ex) {
+		HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+
+		if (ex instanceof TookException) {
+			httpStatus = ((TookException)ex).getErrorCode().getStatus();
+		} else {
+			ResponseStatus responseStatus = AnnotationUtils.findAnnotation(ex.getClass(), ResponseStatus.class);
+			if (responseStatus != null) {
+				httpStatus = responseStatus.value();
+			}
+		}
+
+		return httpStatus == HttpStatus.INTERNAL_SERVER_ERROR;
+	}
+
 }


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
* #121 

## 📌 개발 이유
- 예외 모니터링 시에 slack 알림 조건 수정

## 💻 수정 사항
## 알림 조건 수정
### 예외가 TookException인 경우
- TookException 내부에 설정된 errorCode의 HTTP 상태가 500(INTERNAL_SERVER_ERROR)일 때 

### 예외가 TookException이 아닌 경우
- 예외 클래스에 @ResponseStatus가 적용되어 있다면 그 상태가 500이어야 함
- @ResponseStatus가 없는 경우에는 기본값 500으로 간주되어 알림 전송


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 이제 HTTP 500 내부 서버 오류가 발생한 경우에만 슬랙 오류 알림이 전송됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->