### PR TITLE
[Refactor] 명함 상세정보에 previewInfo 정보 추가

### DIFF
--- a/src/main/java/com/evenly/took/feature/card/application/CardService.java
+++ b/src/main/java/com/evenly/took/feature/card/application/CardService.java
@@ -134,7 +134,9 @@ public class CardService {
 				folderResponses,
 				memo,
 				baseResponse.imagePath(),
-				baseResponse.isPrimary()
+				baseResponse.isPrimary(),
+				baseResponse.previewInfoType(),
+				baseResponse.previewInfo()
 			);
 		}
 	}
@@ -324,7 +326,7 @@ public class CardService {
 		ReceivedCard receivedCard = findReceivedCardByUserAndCardId(user.getId(), request.cardId());
 		receivedCard.updateMemo(request.memo());
 	}
-	
+
 	@Transactional
 	public void updateReceivedCardsMemo(User user, List<SetReceivedCardsMemoRequest.CardMemo> cardMemos) {
 		for (SetReceivedCardsMemoRequest.CardMemo cardMemo : cardMemos) {

--- a/src/main/java/com/evenly/took/feature/card/dto/response/CardDetailResponse.java
+++ b/src/main/java/com/evenly/took/feature/card/dto/response/CardDetailResponse.java
@@ -3,6 +3,7 @@ package com.evenly.took.feature.card.dto.response;
 import java.util.List;
 
 import com.evenly.took.feature.card.domain.Job;
+import com.evenly.took.feature.card.domain.PreviewInfoType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,6 +57,12 @@ public record CardDetailResponse(
 	String imagePath,
 
 	@Schema(description = "대표 명함인지 확인", example = "true")
-	Boolean isPrimary
+	Boolean isPrimary,
+
+	@Schema(description = "썸네일 대표 정보 타입", example = "PROJECT")
+	PreviewInfoType previewInfoType,
+
+	@Schema(description = "대표 정보에 따른 상세 내용")
+	PreviewInfoResponse previewInfo
 ) {
 }

--- a/src/main/java/com/evenly/took/feature/card/mapper/CardMapper.java
+++ b/src/main/java/com/evenly/took/feature/card/mapper/CardMapper.java
@@ -112,6 +112,8 @@ public interface CardMapper {
 
 	@Mapping(source = "career.job", target = "job")
 	@Mapping(source = "career.detailJobEn", target = "detailJob")
+	@Mapping(source = "previewInfo", target = "previewInfoType")
+	@Mapping(source = "card", target = "previewInfo", qualifiedByName = "toPreviewInfoResponse")
 	CardDetailResponse toCardDetailResponse(Card card);
 
 	ProjectResponse toProjectResponse(Project project);


### PR DESCRIPTION
<!--- 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[Feat]`  :  기능 추가 구현
- `[Fix]`  : 코드 수정, 버그/오류 해결
- `[Performance]` : 개선할 성능 이슈
- `[Docs]` : README 등의 문서 수정
- `[Deploy]` : 배포 관련
- `[Refactor]` : 코드 리팩토링(기능 변경 없이 코드만 수정할 때)
- `[Test]`: 테스트 추가/수정
- `[Hotfix]` : 급한 핫픽스
-->

### 관련 이슈가 있다면 적어주세요.
- #106 

## 📌 개발 이유
- 명함 수정 시 데이터 조회 목적

## 💻 수정 사항
- /api/card/detail API 수정
- 명함 상세정보에 previewInfo, previewInfoType 정보 추가 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 카드 상세 정보에 미리보기 타입과 미리보기 정보가 추가되어 더 많은 정보를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->